### PR TITLE
Rename get_maxOrder -> get_order and get_numVars -> get_numvars.

### DIFF
--- a/perf/fateman.jl
+++ b/perf/fateman.jl
@@ -1,0 +1,34 @@
+using TaylorSeries
+
+set_variables("x", numvars=4, order=40)
+
+function fateman1(degree::Int)
+    T = Int128
+    oneH = HomogeneousPolynomial(one(T), 0)
+    # s = 1 + x + y + z + w
+    s = TaylorN( [oneH, HomogeneousPolynomial([one(T),one(T),one(T),one(T)],1)], degree )
+    s = s^degree
+    # s is converted to order 2*ndeg
+    s = TaylorN(s, 2*degree)
+
+    s * ( s+TaylorN(oneH, 2*degree) )
+end
+
+f1 = fateman1(0)
+println("Fateman 1:")
+@time f1 = fateman1(20)
+
+function fateman2(degree::Int)
+    T = Int128
+    oneH = HomogeneousPolynomial(one(T), 0)
+    # s = 1 + x + y + z + w
+    s = TaylorN( [oneH, HomogeneousPolynomial([one(T),one(T),one(T),one(T)],1)], degree )
+    s = s^degree
+    # s is converted to order 2*ndeg
+    s = TaylorN(s, 2*degree)
+    return s^2 + s
+end
+
+f2 = fateman2(0);
+println("Fateman 2:")
+@time f2 = fateman2(20);

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -40,7 +40,7 @@ export Taylor1, TaylorN, HomogeneousPolynomial
 export taylor1_variable, taylorN_variable, get_coeff,
     diffTaylor, integTaylor, evaluate, deriv,
     show_params_TaylorN,
-    get_maxOrder, get_numVars,
+    get_order, get_numvars,
     set_variables,
     ∇, jacobian, hessian
 

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -115,7 +115,7 @@ function pretty_print{T<:Number}(a::TaylorN{T})
 end
 
 function homogPol2str{T<:Number}(a::HomogeneousPolynomial{T})
-    numVars = _params_TaylorN_.numVars
+    numVars = get_numvars()
     order = a.order
     z = zero(T)
     space = utf8(" ")
@@ -197,7 +197,7 @@ name_taylorNvar(i::Int) = string(" ", _params_TaylorN_.variable_names[i])
 # summary
 summary{T<:Number}(a::Taylor1{T}) = string(a.order, "-order ", typeof(a), ":")
 function summary{T<:Number}(a::Union(HomogeneousPolynomial{T}, TaylorN{T}))
-    string(a.order, "-order ", typeof(a), " in ", _params_TaylorN_.numVars, " variables:")
+    string(a.order, "-order ", typeof(a), " in ", get_numvars(), " variables:")
 end
 
 # show

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -115,7 +115,7 @@ function pretty_print{T<:Number}(a::TaylorN{T})
 end
 
 function homogPol2str{T<:Number}(a::HomogeneousPolynomial{T})
-    numVars = _params_taylorN.numVars
+    numVars = _params_TaylorN_.numVars
     order = a.order
     z = zero(T)
     space = utf8(" ")
@@ -191,13 +191,13 @@ function numbr2str{T<:Real}(zz::Complex{T}, ifirst::Bool=false)
 end
 
 #name_taylorNvar(n::Int) = string("⋅x", subscriptify(n))
-name_taylorNvar(i::Int) = string(" ", _params_taylorN.variable_names[i])
+name_taylorNvar(i::Int) = string(" ", _params_TaylorN_.variable_names[i])
 
 
 # summary
 summary{T<:Number}(a::Taylor1{T}) = string(a.order, "-order ", typeof(a), ":")
 function summary{T<:Number}(a::Union(HomogeneousPolynomial{T}, TaylorN{T}))
-    string(a.order, "-order ", typeof(a), " in ", _params_taylorN.numVars, " variables:")
+    string(a.order, "-order ", typeof(a), " in ", _params_TaylorN_.numVars, " variables:")
 end
 
 # show

--- a/src/hashtables.jl
+++ b/src/hashtables.jl
@@ -26,25 +26,25 @@ end
 `HomogeneousPolynomial`""" ->
 function show_params_TaylorN()
     info( """Parameters for `TaylorN` and `HomogeneousPolynomial`:
-    Maximum order       = $(_params_taylorN.maxOrder)
-    Number of variables = $(_params_taylorN.numVars)
-    Variable names      = $(_params_taylorN.variable_names)
+    Maximum order       = $(_params_TaylorN_.maxOrder)
+    Number of variables = $(_params_TaylorN_.numVars)
+    Variable names      = $(_params_TaylorN_.variable_names)
     """)
     nothing
 end
 
-global const _params_taylorN = ParamsTaylorN(6, 2, UTF8String["x₁", "x₂"])
+global const _params_TaylorN_ = ParamsTaylorN(6, 2, UTF8String["x₁", "x₂"])
 
 
 
 
 ## Utilities to get/set the maximum order and number of variables;
 ## they reset the hash tables
-get_order() = _params_taylorN.maxOrder
-# set_maxOrder(n::Int) = set_params_TaylorN(n, _params_taylorN.numVars)
+get_order() = _params_TaylorN_.maxOrder
+# set_maxOrder(n::Int) = set_params_TaylorN(n, _params_TaylorN_.numVars)
 
-get_numvars() = _params_taylorN.numVars
-# set_numVars(n::Int) = set_params_TaylorN(_params_taylorN.maxOrder, n)
+get_numvars() = _params_TaylorN_.numVars
+# set_numVars(n::Int) = set_params_TaylorN(_params_TaylorN_.maxOrder, n)
 
 
 ## Hash tables
@@ -131,8 +131,8 @@ const indicesTable, sizeTable, posTable = generateTables()
 gc();
 
 
-get_variable_names() = _params_taylorN.variable_names
-set_variable_names{T<:String}(names::Vector{T}) = _params_taylorN.variable_names = names
+get_variable_names() = _params_TaylorN_.variable_names
+set_variable_names{T<:String}(names::Vector{T}) = _params_TaylorN_.variable_names = names
 
 
 @doc doc"""`set_variables` sets the names and number of the Taylor variables,
@@ -143,13 +143,13 @@ function set_variables{T}(R::Type, names::Vector{T}; order=6)
     num_vars = length(names)
     num_vars >= 1 || error("Number of variables must be at least 1")
 
-    _params_taylorN.variable_names = names
+    _params_TaylorN_.variable_names = names
 
-    if !(order == _params_taylorN.maxOrder && num_vars == _params_taylorN.numVars)
+    if !(order == _params_TaylorN_.maxOrder && num_vars == _params_TaylorN_.numVars)
         # if these are unchanged, no need to regenerate tables
 
-        _params_taylorN.maxOrder = order
-        _params_taylorN.numVars = num_vars
+        _params_TaylorN_.maxOrder = order
+        _params_TaylorN_.numVars = num_vars
 
         resize!(indicesTable,order+1)
         resize!(sizeTable,order+1)

--- a/src/hashtables.jl
+++ b/src/hashtables.jl
@@ -11,40 +11,35 @@
 
     Fieldnames:
 
-    - maxOrder: maximum order (degree) of the polynomials
-    - numVars : maximum number of variables
+    - order:     order (degree) of the polynomials
+    - num_vars : number of variables
 
     These parameters can be changed using `set_params_TaylorN(order,numVars)`
     """ ->
 type ParamsTaylorN
-    maxOrder :: Int
-    numVars  :: Int
+    order :: Int
+    num_vars  :: Int
     variable_names :: Array{UTF8String,1}
-end
-
-@doc """Display the current parameters for `TaylorN` and
-`HomogeneousPolynomial`""" ->
-function show_params_TaylorN()
-    info( """Parameters for `TaylorN` and `HomogeneousPolynomial`:
-    Maximum order       = $(_params_TaylorN_.maxOrder)
-    Number of variables = $(_params_TaylorN_.numVars)
-    Variable names      = $(_params_TaylorN_.variable_names)
-    """)
-    nothing
 end
 
 global const _params_TaylorN_ = ParamsTaylorN(6, 2, UTF8String["x₁", "x₂"])
 
 
+@doc """Display the current parameters for `TaylorN` and
+`HomogeneousPolynomial`""" ->
+function show_params_TaylorN()
+    info( """Parameters for `TaylorN` and `HomogeneousPolynomial`:
+    Maximum order       = $(_params_TaylorN_.order)
+    Number of variables = $(_params_TaylorN_.numvars)
+    Variable names      = $(_params_TaylorN_.variable_names)
+    """)
+    nothing
+end
 
 
-## Utilities to get/set the maximum order and number of variables;
-## they reset the hash tables
-get_order() = _params_TaylorN_.maxOrder
-# set_maxOrder(n::Int) = set_params_TaylorN(n, _params_TaylorN_.numVars)
-
-get_numvars() = _params_TaylorN_.numVars
-# set_numVars(n::Int) = set_params_TaylorN(_params_TaylorN_.maxOrder, n)
+## Utilities to get the maximum order and number of variables
+get_order() = _params_TaylorN_.order
+get_numvars() = _params_TaylorN_.num_vars
 
 
 ## Hash tables
@@ -145,11 +140,11 @@ function set_variables{T}(R::Type, names::Vector{T}; order=6)
 
     _params_TaylorN_.variable_names = names
 
-    if !(order == _params_TaylorN_.maxOrder && num_vars == _params_TaylorN_.numVars)
+    if !(order == get_order() && num_vars == get_numvars())
         # if these are unchanged, no need to regenerate tables
 
-        _params_TaylorN_.maxOrder = order
-        _params_TaylorN_.numVars = num_vars
+        _params_TaylorN_.order = order
+        _params_TaylorN_.num_vars = num_vars
 
         resize!(indicesTable,order+1)
         resize!(sizeTable,order+1)

--- a/src/hashtables.jl
+++ b/src/hashtables.jl
@@ -40,10 +40,10 @@ global const _params_taylorN = ParamsTaylorN(6, 2, UTF8String["x₁", "x₂"])
 
 ## Utilities to get/set the maximum order and number of variables;
 ## they reset the hash tables
-get_maxOrder() = _params_taylorN.maxOrder
+get_order() = _params_taylorN.maxOrder
 # set_maxOrder(n::Int) = set_params_TaylorN(n, _params_taylorN.numVars)
 
-get_numVars() = _params_taylorN.numVars
+get_numvars() = _params_taylorN.numVars
 # set_numVars(n::Int) = set_params_TaylorN(_params_taylorN.maxOrder, n)
 
 
@@ -63,8 +63,8 @@ get_numVars() = _params_taylorN.numVars
   (lexicographic) position of the corresponding monomial.
 """ ->
 function generateTables()
-    maxOrd = get_maxOrder()
-    numVars = get_numVars()
+    maxOrd = get_order()
+    numVars = get_numvars()
 
     arrayInd  = Array(Dict{Int,Array{Int,1}},maxOrd+1)
     arraySize = Array(Int,maxOrd+1)
@@ -160,7 +160,7 @@ function set_variables{T}(R::Type, names::Vector{T}; order=6)
     end
 
     # return a list of the new variables
-    TaylorN{R}[taylorN_variable(R,i) for i in 1:get_numVars()]
+    TaylorN{R}[taylorN_variable(R,i) for i in 1:get_numvars()]
 end
 set_variables{T}(names::Vector{T}; order=6) = set_variables(Float64, names, order=order)
 

--- a/src/utils_TaylorN.jl
+++ b/src/utils_TaylorN.jl
@@ -13,7 +13,7 @@
 function orderH{T}(coeffs::Array{T,1})
     ord = 0
     ll = length(coeffs)
-    for i = 1:_params_taylorN.maxOrder+1
+    for i = 1:_params_TaylorN_.maxOrder+1
         @inbounds num_coeffs = sizeTable[i]
         ll <= num_coeffs && break
         ord += 1
@@ -38,7 +38,7 @@ immutable HomogeneousPolynomial{T<:Number} <: Number
     order   :: Int
 
     function HomogeneousPolynomial( coeffs::Array{T,1}, order::Int )
-        maxOrder = _params_taylorN.maxOrder
+        maxOrder = _params_TaylorN_.maxOrder
         @assert order <= maxOrder
         lencoef = length( coeffs )
         @inbounds num_coeffs = sizeTable[order+1]
@@ -185,19 +185,19 @@ TaylorN{T<:Number}(x::T,order::Int) =
 TaylorN{T<:Number}(x::T) = TaylorN{T}([HomogeneousPolynomial(x)], 0)
 
 ## Shortcut to define TaylorN independent variables
-function taylorN_variable(T::Type, nv::Int, order::Int=_params_taylorN.maxOrder)
-    @assert 0 < nv <= _params_taylorN.numVars
-    v = zeros(T, _params_taylorN.numVars)
+function taylorN_variable(T::Type, nv::Int, order::Int=_params_TaylorN_.maxOrder)
+    @assert 0 < nv <= _params_TaylorN_.numVars
+    v = zeros(T, _params_TaylorN_.numVars)
     @inbounds v[nv] = one(T)
     return TaylorN( HomogeneousPolynomial(v,1), order )
 end
-taylorN_variable(nv::Int, order::Int=_params_taylorN.maxOrder) =
+taylorN_variable(nv::Int, order::Int=_params_TaylorN_.maxOrder) =
     taylorN_variable(Float64, nv, order)
 
 
 ## get_coeff
 function get_coeff(a::HomogeneousPolynomial, v::Array{Int,1})
-    @assert length(v) == _params_taylorN.numVars
+    @assert length(v) == _params_TaylorN_.numVars
     kdic = hash(v)
     @inbounds n = posTable[a.order+1][kdic]
     a.coeffs[n]
@@ -342,8 +342,8 @@ end
 function *(a::HomogeneousPolynomial, b::HomogeneousPolynomial)
     T = promote_type( eltype(a), eltype(b) )
     order = a.order + b.order
-    if order > _params_taylorN.maxOrder
-        return HomogeneousPolynomial(zero(T), _params_taylorN.maxOrder)
+    if order > _params_TaylorN_.maxOrder
+        return HomogeneousPolynomial(zero(T), _params_TaylorN_.maxOrder)
     end
     (iszero(a) || iszero(b)) && return HomogeneousPolynomial(zero(T), order)
 
@@ -355,7 +355,7 @@ function *(a::HomogeneousPolynomial, b::HomogeneousPolynomial)
     end
 
     coeffs = zeros(T, num_coeffs)
-    iaux = zeros(Int, _params_taylorN.numVars)
+    iaux = zeros(Int, _params_TaylorN_.numVars)
     @inbounds posTb = posTable[order+1]
     @inbounds for na = 1:num_coeffs_a
         ca = a.coeffs[na]
@@ -365,7 +365,7 @@ function *(a::HomogeneousPolynomial, b::HomogeneousPolynomial)
             cb = b.coeffs[nb]
             cb == zero(T) && continue
             indb = indicesTable[b.order+1][nb]
-            @simd for i = 1:_params_taylorN.numVars
+            @simd for i = 1:_params_TaylorN_.numVars
                 @inbounds iaux[i] = inda[i]+indb[i]
             end
             kdic = hash(iaux)
@@ -560,21 +560,21 @@ end
 function square(a::HomogeneousPolynomial)
     T = eltype(a)
     order = 2*a.order
-    if order > _params_taylorN.maxOrder
-        return HomogeneousPolynomial(zero(T), _params_taylorN.maxOrder)
+    if order > _params_TaylorN_.maxOrder
+        return HomogeneousPolynomial(zero(T), _params_TaylorN_.maxOrder)
     end
     @inbounds num_coeffs_a = sizeTable[a.order+1]
     @inbounds num_coeffs  = sizeTable[order+1]
     two = convert(T,2)
     coeffs = zeros(T, num_coeffs)
-    iaux = zeros( _params_taylorN.numVars )
+    iaux = zeros( _params_TaylorN_.numVars )
     @inbounds posTb = posTable[order+1]
 
     @inbounds for na = 1:num_coeffs_a
         ca = a.coeffs[na]
         ca == zero(T) && continue
         inda = indicesTable[a.order+1][na]
-        @inbounds for i = 1:_params_taylorN.numVars
+        @inbounds for i = 1:_params_TaylorN_.numVars
             iaux[i] = 2inda[i]
         end
         kdic = hash(iaux)
@@ -584,7 +584,7 @@ function square(a::HomogeneousPolynomial)
             cb = a.coeffs[nb]
             cb == zero(T) && continue
             indb = indicesTable[a.order+1][nb]
-            @simd for i = 1:_params_taylorN.numVars
+            @simd for i = 1:_params_TaylorN_.numVars
                 @inbounds iaux[i] = inda[i]+indb[i]
             end
             kdic = hash(iaux)
@@ -737,7 +737,7 @@ end
 """Partial differentiation of a HomogeneousPolynomial series with respect
 to the r-th variable"""
 function diffTaylor(a::HomogeneousPolynomial, r::Int)
-    @assert 1 <= r <= _params_taylorN.numVars
+    @assert 1 <= r <= _params_TaylorN_.numVars
     T = eltype(a)
     a.order == 0 && return HomogeneousPolynomial(zero(T))
     @inbounds num_coeffs = sizeTable[a.order]

--- a/src/utils_TaylorN.jl
+++ b/src/utils_TaylorN.jl
@@ -65,7 +65,7 @@ HomogeneousPolynomial{T<:Number}(x::T) = HomogeneousPolynomial{T}([x], 0)
 
 eltype{T<:Number}(::HomogeneousPolynomial{T}) = T
 length(a::HomogeneousPolynomial) = length( a.coeffs )
-get_maxOrder(a::HomogeneousPolynomial) = a.order
+get_order(a::HomogeneousPolynomial) = a.order
 
 
 ## zero and one ##
@@ -210,7 +210,7 @@ end
 ## Type, length ##
 eltype{T<:Number}(::TaylorN{T}) = T
 length(a::TaylorN) = length( a.coeffs )
-get_maxOrder(x::TaylorN) = x.order
+get_order(x::TaylorN) = x.order
 
 ## zero and one ##
 zero{T<:Number}(a::TaylorN{T}) = TaylorN(zero(T), a.order)
@@ -777,7 +777,7 @@ diffTaylor(a::TaylorN) = diffTaylor(a, 1)
 ## Gradient, jacobian and hessian
 function gradient(f::TaylorN)
     T = eltype(f)
-    numVars = get_numVars()
+    numVars = get_numvars()
     grad = Array(TaylorN{T}, numVars)
     @inbounds for nv = 1:numVars
         grad[nv] = diffTaylor(f, nv)
@@ -788,7 +788,7 @@ end
 ∇(f::TaylorN) = gradient(f)
 
 function jacobian{T<:Number}(vf::Array{TaylorN{T},1})
-    numVars = get_numVars()
+    numVars = get_numvars()
     @assert length(vf) == numVars
     jac = Array(T, (numVars,numVars))
 
@@ -801,7 +801,7 @@ end
 
 function jacobian{T<:Number,S<:Number}(vf::Array{TaylorN{T},1},vals::Array{S,1})
     R = promote_type(T,S)
-    numVars = get_numVars()
+    numVars = get_numvars()
     @assert length(vf) == numVars == length(vals)
     jac = Array(R, (numVars,numVars))
 
@@ -817,7 +817,7 @@ end
 
 hessian{T<:Number,S<:Number}(f::TaylorN{T}, vals::Array{S,1}) =
     (R = promote_type(T,S); jacobian( gradient(f), vals::Array{R,1}) )
-hessian{T<:Number}(f::TaylorN{T}) = hessian( f, zeros(T, get_numVars()) )
+hessian{T<:Number}(f::TaylorN{T}) = hessian( f, zeros(T, get_numvars()) )
 
 ## TODO: Integration...
 
@@ -829,7 +829,7 @@ TaylorN result.
 function evaluate{T<:Number,S<:Union(Real,Complex)}(a::HomogeneousPolynomial{T},
     vals::Array{S,1} )
 
-    numVars = get_numVars()
+    numVars = get_numvars()
     @assert length(vals) == numVars
     R = promote_type(T,S)
     suma = convert(TaylorN{R}, a)
@@ -844,7 +844,7 @@ end
 function evaluate{T<:Number,S<:Union(Real,Complex)}(a::TaylorN{T},
     vals::Array{S,1} )
 
-    numVars = get_numVars()
+    numVars = get_numvars()
     @assert length(vals) == numVars
     R = promote_type(T,S)
     suma = convert(TaylorN{R}, a)
@@ -856,7 +856,7 @@ function evaluate{T<:Number,S<:Union(Real,Complex)}(a::TaylorN{T},
     return suma.coeffs[1].coeffs[1]
 end
 
-evaluate{T<:Number}(a::TaylorN{T}) = evaluate(a, zeros(T, get_numVars()))
+evaluate{T<:Number}(a::TaylorN{T}) = evaluate(a, zeros(T, get_numvars()))
 
 ## Evaluates HomogeneousPolynomials and TaylorN on a val of the nv variable
 ## using Horner's rule on the nv variable
@@ -864,7 +864,7 @@ function horner{T<:Number,S<:Union(Real,Complex)}(a::HomogeneousPolynomial{T},
     @compat b::Tuple{Int,S} )
 
     nv, val = b
-    numVars = get_numVars()
+    numVars = get_numvars()
     @assert 1 <= nv <= numVars
     R = promote_type(T,S)
     @inbounds indTb = indicesTable[a.order+1]
@@ -899,7 +899,7 @@ function horner{T<:Number,S<:Union(Real,Complex)}(a::TaylorN{T},
     @compat b::Tuple{Int,S} )
 
     nv, val = b
-    @assert 1 <= nv <= get_numVars()
+    @assert 1 <= nv <= get_numvars()
     R = promote_type(T,S)
 
     suma = TaylorN(zero(R), a.order)
@@ -915,7 +915,7 @@ Returns the vector position (of the homogeneous-polynomial) of order `order`,
 where the variable `nv` has order `ord`
 """ ->
 function order_posTb(order::Int, nv::Int, ord::Int)
-    @assert order <= get_maxOrder()
+    @assert order <= get_order()
     @inbounds indTb = indicesTable[order+1]
     @inbounds num_coeffs = sizeTable[order+1]
     posV = Int[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,8 +121,8 @@ facts("Tests for HomogeneousPolynomial and TaylorN") do
     @fact TaylorSeries.indicesTable[2][1] == [1,0]  => true
     @fact TaylorSeries.posTable[4][hash([2,1])] == 2  => true
 
-    @fact get_maxOrder() == 6  => true
-    @fact get_numVars() == 2  => true
+    @fact get_order() == 6  => true
+    @fact get_numvars() == 2  => true
 
     x, y = set_variables("x y", order=6)
     @fact x.order == 6 => true
@@ -140,7 +140,7 @@ facts("Tests for HomogeneousPolynomial and TaylorN") do
     @fact ones(xH,1) == [HomogeneousPolynomial(1), xH+yH]  => true
     @fact ones(HomogeneousPolynomial{Complex{Int}},0) ==
         [HomogeneousPolynomial(1+0im)]  => true
-    @fact get_maxOrder(zeroT) == 1  => true
+    @fact get_order(zeroT) == 1  => true
     @fact get_coeff(xT,[1,0]) == 1  => true
     @fact get_coeff(yH,[1,0]) == 0  => true
     @fact convert(HomogeneousPolynomial{Int64},[1,1]) == xH+yH  => true
@@ -162,8 +162,8 @@ facts("Tests for HomogeneousPolynomial and TaylorN") do
     @fact one(yH) == xH+yH  => true
     @fact xH * true == xH  => true
     @fact false * yH == zero(yH)  => true
-    @fact get_maxOrder(yH) == 1  => true
-    @fact get_maxOrder(xT) == 17  => true
+    @fact get_order(yH) == 1  => true
+    @fact get_order(xT) == 17  => true
     @fact xT * true == xT  => true
     @fact false * yT == zero(yT)  => true
 
@@ -171,15 +171,15 @@ facts("Tests for HomogeneousPolynomial and TaylorN") do
     @fact one(xT) == TaylorN(1,5)  => true
     @fact TaylorN(zeroT,5) == 0  => true
     @fact TaylorN(uT) == convert(TaylorN{Complex},1)  => true
-    @fact get_numVars() == 2  => true
-    @fact length(uT) == get_maxOrder()+1  => true
+    @fact get_numvars() == 2  => true
+    @fact length(uT) == get_order()+1  => true
     @fact eltype(convert(TaylorN{Complex128},1)) == Complex128  => true
 
     @fact 1+xT+yT == TaylorN(1,1) + TaylorN([xH,yH],1)  => true
     @fact xT-yT-1 == TaylorN([-1,xH-yH])  => true
     @fact xT*yT == TaylorN([HomogeneousPolynomial([0,1,0],2)])  => true
     @fact (1/(1-xT)).coeffs[4] == HomogeneousPolynomial(1.0,3)  => true
-    @fact xH^20 == HomogeneousPolynomial([0],get_maxOrder())  => true
+    @fact xH^20 == HomogeneousPolynomial([0],get_order())  => true
     @fact (yT/(1-xT)).coeffs[5] == xH^3 * yH  => true
     @fact mod(1+xT,1) == +xT  => true
     @fact (rem(1+xT,1)).coeffs[1] == 0  => true


### PR DESCRIPTION
Also replaces direct accesses of fields in `_params_TaylorN_`  with calls to `get_order` and `get_numvars`. 

Note that these calls are inlined and so do not affect performance (checked with the Fateman benchmarks, which I have separated out into a file `fateman.jl` in the new `perf` directory).