### PR TITLE
Convert arrays of coefficients [3,4,5,6] into Int64s by using arithmetic base (order+1).

### DIFF
--- a/src/TaylorN.jl
+++ b/src/TaylorN.jl
@@ -359,11 +359,12 @@ function *(a::HomogeneousPolynomial, b::HomogeneousPolynomial)
             cb = b.coeffs[nb]
             cb == zero(T) && continue
             indb = index_table[b.order+1][nb]
-            @simd for i = 1:get_numvars()
-                @inbounds iaux[i] = inda[i]+indb[i]
-            end
-            kdic = hash(iaux)
-            pos = posTb[kdic]
+            #@simd for i = 1:get_numvars()
+            #    @inbounds iaux[i] = inda[i]+indb[i]
+            #end
+            iaux = inda + indb
+            #kdic = hash(iaux)
+            pos = posTb[iaux]
             coeffs[pos] += ca * cb
         end
     end
@@ -570,23 +571,23 @@ function square(a::HomogeneousPolynomial)
     @inbounds for na = 1:num_coeffs_a
         ca = a.coeffs[na]
         ca == zero(T) && continue
-        inda = index_table[a.order+1][na]
-        @inbounds for i = 1:get_numvars()
-            iaux[i] = 2inda[i]
-        end
-        kdic = hash(iaux)
-        pos = posTb[kdic]
-        coeffs[pos] += ca * ca
+        @inbounds inda = index_table[a.order+1][na]
+        #@inbounds for i = 1:get_numvars()
+        #    iaux[i] = 2inda[i]
+        #end
+        #kdic = hash(iaux)
+        @inbounds pos = posTb[2*inda]
+        @inbounds coeffs[pos] += ca * ca
         @inbounds for nb = na+1:num_coeffs_a
-            cb = a.coeffs[nb]
+            @inbounds cb = a.coeffs[nb]
             cb == zero(T) && continue
-            indb = index_table[a.order+1][nb]
-            @simd for i = 1:get_numvars()
-                @inbounds iaux[i] = inda[i]+indb[i]
-            end
-            kdic = hash(iaux)
-            pos = posTb[kdic]
-            coeffs[pos] += two * ca * cb
+            @inbounds indb = index_table[a.order+1][nb]
+            #@simd for i = 1:get_numvars()
+            #   @inbounds iaux[i] = inda[i]+indb[i]
+            #end
+            #kdic = hash(iaux)
+            @inbounds pos = posTb[inda+indb]
+            @inbounds coeffs[pos] += two * ca * cb
         end
     end
 

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -14,6 +14,7 @@ using Compat
 @compat eachindex
 @compat round
 
+import Base: ==, +, -, *, /, ^
 import Base: zero, one, zeros, ones,
     convert, promote_rule, promote, eltype, length, show,
     real, imag, conj, ctranspose,

--- a/src/hash_tables.jl
+++ b/src/hash_tables.jl
@@ -21,12 +21,14 @@
 
 function generate_tables(num_vars, order)
 
-    index_table = [generate_index_vectors(num_vars, i) for i in 0:order]
+    coeff_table = [generate_index_vectors(num_vars, i) for i in 0:order]
+
+    index_table = Vector{Int}[map(x->in_base(order, x), coeffs) for coeffs in coeff_table]
 
     pos_table = map(make_inverse_dict, index_table)
     size_table = map(length, index_table)
 
-    index_table, size_table, pos_table
+    coeff_table, index_table, size_table, pos_table
 
 end
 
@@ -56,10 +58,23 @@ function make_forward_dict(v::Vector)
 end
 
 function make_inverse_dict(v::Vector)
-    Dict([hash(x)=>i for (i,x) in enumerate(v)])
+    Dict([x=>i for (i,x) in enumerate(v)])
+end
+
+@doc "Convert vector v of non-negative integers to base order+1" ->
+function in_base(order, v)
+    order = order+1
+
+    result = 0
+
+    for i in v
+        result = result*order + i
+    end
+
+    result
 end
 
 
-const index_table, size_table, pos_table = generate_tables(get_numvars(), get_order())
+const coeff_table, index_table, size_table, pos_table = generate_tables(get_numvars(), get_order())
 gc();
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -60,11 +60,12 @@ function set_variables{T<:String}(R::Type, names::Vector{T}; order=6)
         _params_TaylorN_.order = order
         _params_TaylorN_.num_vars = num_vars
 
+        resize!(coeff_table,order+1)
         resize!(index_table,order+1)
         resize!(size_table,order+1)
         resize!(pos_table,order+1)
 
-        index_table[:], size_table[:], pos_table[:] = generate_tables(num_vars, order)
+        coeff_table[:], index_table[:], size_table[:], pos_table[:] = generate_tables(num_vars, order)
         gc();
     end
 

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -141,7 +141,7 @@ function numbr2str{T<:Real}(zz::Complex{T}, ifirst::Bool=false)
 end
 
 #name_taylorNvar(n::Int) = string("⋅x", subscriptify(n))
-name_taylorNvar(i::Int) = string(" ", _params_TaylorN_.variable_names[i])
+name_taylorNvar(i::Int) = string(" ", get_variable_names()[i])
 
 
 # summary

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -74,7 +74,7 @@ function homogPol2str{T<:Number}(a::HomogeneousPolynomial{T})
     iIndices = zeros(Int, numVars)
     for pos = 1:size_table[order+1]
         monom::UTF8String = string("")
-        @inbounds iIndices[:] = index_table[order+1][pos]
+        @inbounds iIndices[:] = coeff_table[order+1][pos]
         for ivar = 1:numVars
             powivar = iIndices[ivar]
             if powivar == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,8 +118,10 @@ facts("Tests for HomogeneousPolynomial and TaylorN") do
     @fact eltype(set_variables(BigInt, "x y", order=6))  --> TaylorN{BigInt}
     @fact eltype(set_variables("x y", order=6))  --> TaylorN{Float64}
 
-    @fact TaylorSeries.index_table[2][1] == [1,0]  --> true
-    @fact TaylorSeries.pos_table[4][hash([2,1])] == 2  --> true
+    @fact TaylorSeries.coeff_table[2][1] == [1,0]  --> true
+    @fact TaylorSeries.index_table[2][1] == 7  --> true
+    @fact TaylorSeries.in_base(get_order(),[2,1]) == 15  --> true
+    @fact TaylorSeries.pos_table[4][15] == 2  --> true
 
     @fact get_order() == 6  --> true
     @fact get_numvars() == 2  --> true
@@ -257,6 +259,33 @@ facts("Testing an identity proved by Euler (8 variables)") do
     @fact lhs == rhs  --> true
     v = randn(8)
     @fact evaluate( rhs, v) == evaluate( lhs, v)  --> true
+end
+
+facts("A test inspired on a test by Fateman (takes few seconds))") do
+    x, y, z, w = set_variables(Int128, "x", numvars=4, order=40)
+
+    function fateman2(degree::Int)
+        T = Int128
+        oneH = HomogeneousPolynomial(one(T), 0)
+        # s = 1 + x + y + z + w
+        s = TaylorN( [oneH, HomogeneousPolynomial([one(T),one(T),one(T),one(T)],1)], degree )
+        s = s^degree
+        # s is converted to order 2*ndeg
+        s = TaylorN(s, 2*degree)
+        return s^2 + s
+    end
+
+    function fateman3(degree::Int)
+        s = x + y + z + w + 1
+        s = s^degree
+        s * (s+1)
+    end
+
+    f2 = fateman2(20)
+    f3 = fateman3(20)
+    c = get_coeff(f2,[1,6,7,20])
+    @fact c == 128358585324486316800 --> true
+    @fact get_coeff(f2,[1,6,7,20]) == c --> true
 end
 
 exitstatus()


### PR DESCRIPTION
E.g. [3,4,5,6] with order 9 becomes the integer 3456.