### PR TITLE
Replace Mathematica .nb by a .m script, and adapt fateman.jl

### DIFF
--- a/perf/fateman.jl
+++ b/perf/fateman.jl
@@ -45,8 +45,13 @@ function run_fateman(N)
         println("Running $f")
         @time result = f(N)
         push!(results, result)
+        t = Inf
+        for i = 1:5
+            ti = @elapsed f(N)
+            t = min(t,ti)
+        end
+        println("\t Min time of 5 runs:", t)
     end
-
     results
 end
 

--- a/perf/timing_Fateman.m
+++ b/perf/timing_Fateman.m
@@ -1,0 +1,27 @@
+(* Timing a test by Fateman
+
+In a mac, run this as
+/Applications/Mathematica.app/Contents/MacOS/MathematicaScript -script ./timing_Fateman.m)
+
+The `timeit` function is slightly modified from
+https://github.com/JuliaLang/julia/blob/master/test/perf/micro/perf.nb
+which is licensed under MIT
+
+*)
+
+ClearAll[timeit];
+SetAttributes[timeit, HoldFirst];
+timeit[ex_, name_String] := Module[
+        {t},
+        t = Infinity;
+        Do[
+                t = Min[t, N[First[AbsoluteTiming[ex]]]];
+                ,
+                {i, 1, 5}
+        ];
+    Print["mathematica,", name, ",min(time),", t];
+];
+
+(* Print[First[AbsoluteTiming[Function[n,Expand[(1+x+y+z+w)^n * (1+(1+x+y+z+w)^n)]][20]]]] *)
+
+timeit[Function[n,Expand[(1+x+y+z+w)^n * (1+(1+x+y+z+w)^n)]][20],"fateman"]


### PR DESCRIPTION
This saves LOT OF lines, and seems to be the correct way of comparing
the time of the calculation. The time returned is the minimum time
for performing 5 times the calculation.

To be fair, fateman.jl also computes the minimum of 5 runs. A fair comparison of 
what Mathematica does, one has to compare with fateman2 or fateman4 output.