### PR TITLE
Precompilation and solves a printing issue for T<:Real but not the usual cases

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.3
+julia 0.4
 Compat 0.6
-Docile
 FactCheck 0.3.0

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -6,10 +6,6 @@ __precompile__(true)
 
 module TaylorSeries
 
-if VERSION < v"0.4.0-dev"
-    using Docile
-end
-
 using Compat
 
 import Base: ==, +, -, *, /, ^

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -2,6 +2,8 @@
 #
 # Handles Taylor series of arbitrary but finite order
 
+__precompile__(true)
+
 module TaylorSeries
 
 if VERSION < v"0.4.0-dev"

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -93,10 +93,14 @@ function homogPol2str{T<:Number}(a::HomogeneousPolynomial{T})
 end
 function numbr2str{T<:Real}(zz::T, ifirst::Bool=false)
     zz == zero(T) && return string( zz )
-    plusmin = zz > zero(T) ? string("+ ") : string("- ")
-    if ifirst
-        plusmin = zz > zero(T) ? string("") : string("- ")
-    end
+    plusmin = ifelse( ifirst, string(""), string("+ ") )
+    return string(plusmin, zz)
+end
+function numbr2str{T<:Union{AbstractFloat,Integer,Irrational,Rational}}(zz::T,
+    ifirst::Bool=false)
+    zz == zero(T) && return string( zz )
+    plusmin = ifelse( zz < zero(T), string("- "),
+                ifelse( ifirst, string(""), string("+ ")) )
     return string(plusmin, abs(zz))
 end
 function numbr2str{T<:Complex}(zz::T, ifirst::Bool=false)

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -96,8 +96,7 @@ function numbr2str{T<:Real}(zz::T, ifirst::Bool=false)
     plusmin = ifelse( ifirst, string(""), string("+ ") )
     return string(plusmin, zz)
 end
-function numbr2str{T<:Union{AbstractFloat,Integer,Irrational,Rational}}(zz::T,
-    ifirst::Bool=false)
+function numbr2str{T<:Union{AbstractFloat,Integer,Rational}}(zz::T, ifirst::Bool=false)
     zz == zero(T) && return string( zz )
     plusmin = ifelse( zz < zero(T), string("- "),
                 ifelse( ifirst, string(""), string("+ ")) )


### PR DESCRIPTION
An example is when T is Interval; in that case, showing the
Taylor series displayed odd results, though the coefficients
were correct

It also adds precompilation