### PR TITLE
Corrects a printing issue for T<:Real (but not the usual cases)

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -91,12 +91,15 @@ function homogPol2str{T<:Number}(a::HomogeneousPolynomial{T})
     end
     return strout[1:end-1]
 end
-function numbr2str{T<:Real}(zz::T, ifirst::Bool=false)
+function numbr2str(zz, ifirst::Bool=false)
+    zz == zero(zz) && return string( zz )
+    plusmin = ifelse( ifirst, string(""), string("+ ") )
+    return string(plusmin, zz)
+end
+function numbr2str{T<:Union{AbstractFloat,Integer,Rational}}(zz::T, ifirst::Bool=false)
     zz == zero(T) && return string( zz )
-    plusmin = zz > zero(T) ? string("+ ") : string("- ")
-    if ifirst
-        plusmin = zz > zero(T) ? string("") : string("- ")
-    end
+    plusmin = ifelse( zz < zero(T), string("- "),
+                ifelse( ifirst, string(""), string("+ ")) )
     return string(plusmin, abs(zz))
 end
 function numbr2str{T<:Complex}(zz::T, ifirst::Bool=false)


### PR DESCRIPTION
An example is when T is Interval, thus T<:Real; in that case, displaying the Taylor series shows odd results, though the coefficients internally are correct. An example of the problem is given in [this comment](https://github.com/JuliaDiff/TaylorSeries.jl/pull/42#issuecomment-177601984). 

This follows from #42; it only deals with the output of the series, and incorporates all suggestions of #42.

