### PR TITLE
Added A_mul_B! and some small improvements

### DIFF
--- a/src/Taylor1.jl
+++ b/src/Taylor1.jl
@@ -676,7 +676,7 @@ end
 
 Multiply a*b and save the result in y.  Extends y to fit the results if necessary.
 """
-function A_mul_B!{T<:Number}(y::Vector{Taylor1{T}},a::Matrix{T},b::Vector{Taylor1{T}})
+function A_mul_B!{T<:Number}(y::Vector{Taylor1{T}},a::Union{Matrix,SparseMatrixCSC},b::Vector{Taylor1{T}})
 
     # determine the maximal order of b
     order = maximum([b1.order for b1 in b])

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -17,7 +17,7 @@ import Base: zero, one, zeros, ones, isinf, isnan,
     convert, promote_rule, promote, eltype, length, show,
     real, imag, conj, ctranspose,
     rem, mod, mod2pi, abs, gradient,
-    sqrt, exp, log, sin, cos, tan
+    sqrt, exp, log, sin, cos, tan, A_mul_B!
 
 export Taylor1, TaylorN, HomogeneousPolynomial
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -305,4 +305,37 @@ facts("High order polynomials test inspired by Fateman (takes a few seconds))") 
     @fact get_coeff(f2,[1,6,7,20]) == c --> true
 end
 
+facts("Matrix multiplication for Taylor1") do
+    order = 30
+    n1 = 100
+    k1 = 90
+
+    tol1 = eps(1.0)
+
+    fake_order = max(n1,k1,order+1)
+    B1 = randn(n1,fake_order)
+    Y1 = randn(k1,fake_order)
+
+    A  = randn(k1,n1)
+
+    # B and Y contain elements of different orders
+    B  = Taylor1{Float64}[Taylor1(collect(B1[i,1:i]),i) for i=1:n1]
+    Y  = Taylor1{Float64}[Taylor1(collect(Y1[k,1:k]),k) for k=1:k1]
+    Bcopy = deepcopy!(B)
+    A_mul_B!(Y,A,B)
+    # Y should be extended after the multilpication
+    @fact reduce(&, [y1.order for y1 in Y] .== Y[1].order) --> true
+    # B should be unchanged
+    @fact B==Bcopy --> true
+
+    # is the result compatible with the matrix multiplication?  We
+    # only check the zeroth order of the Taylor series.
+    y1=sum(Y).coeffs[1]
+    Y=A*B1[:,1]
+    y2=sum(Y)
+    # Sometimes this fails due to a small numerical error
+    @fact abs(y1-y2) < tol1 --> true
+end
+
+
 exitstatus()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -314,28 +314,30 @@ facts("Matrix multiplication for Taylor1") do
     B1 = randn(n1,order)
     Y1 = randn(k1,order)
 
-    A  = randn(k1,n1)
+    A1  = randn(k1,n1)
 
-    # B and Y contain elements of different orders
-    B  = Taylor1{Float64}[Taylor1(collect(B1[i,1:i]),i) for i=1:n1]
-    Y  = Taylor1{Float64}[Taylor1(collect(Y1[k,1:k]),k) for k=1:k1]
-    Bcopy = deepcopy(B)
-    A_mul_B!(Y,A,B)
+    for A in (A1,sparse(A1))
+        # B and Y contain elements of different orders
+        B  = Taylor1{Float64}[Taylor1(collect(B1[i,1:i]),i) for i=1:n1]
+        Y  = Taylor1{Float64}[Taylor1(collect(Y1[k,1:k]),k) for k=1:k1]
+        Bcopy = deepcopy(B)
+        A_mul_B!(Y,A,B)
 
-    # do we get the same result when using the `A*B` form?
-    @fact A*B==Y -->true
-    # Y should be extended after the multilpication
-    @fact reduce(&, [y1.order for y1 in Y] .== Y[1].order) --> true
-    # B should be unchanged
-    @fact B==Bcopy --> true
+        # do we get the same result when using the `A*B` form?
+        @fact A*B==Y -->true
+        # Y should be extended after the multilpication
+        @fact reduce(&, [y1.order for y1 in Y] .== Y[1].order) --> true
+        # B should be unchanged
+        @fact B==Bcopy --> true
 
-    # is the result compatible with the matrix multiplication?  We
-    # only check the zeroth order of the Taylor series.
-    y1=sum(Y).coeffs[1]
-    Y=A*B1[:,1]
-    y2=sum(Y)
-    # Sometimes this fails due to a small numerical error
-    @fact abs(y1-y2) < n1*(eps(y1)+eps(y2)) --> true
+        # is the result compatible with the matrix multiplication?  We
+        # only check the zeroth order of the Taylor series.
+        y1=sum(Y).coeffs[1]
+        Y=A*B1[:,1]
+        y2=sum(Y)
+        # Sometimes this fails due to a small numerical error
+        @fact abs(y1-y2) < n1*(eps(y1)+eps(y2)) --> true
+    end
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,19 +310,20 @@ facts("Matrix multiplication for Taylor1") do
     n1 = 100
     k1 = 90
 
-    tol1 = eps(1.0)
-
-    fake_order = max(n1,k1,order+1)
-    B1 = randn(n1,fake_order)
-    Y1 = randn(k1,fake_order)
+    order = max(n1,k1)
+    B1 = randn(n1,order)
+    Y1 = randn(k1,order)
 
     A  = randn(k1,n1)
 
     # B and Y contain elements of different orders
     B  = Taylor1{Float64}[Taylor1(collect(B1[i,1:i]),i) for i=1:n1]
     Y  = Taylor1{Float64}[Taylor1(collect(Y1[k,1:k]),k) for k=1:k1]
-    Bcopy = deepcopy!(B)
+    Bcopy = deepcopy(B)
     A_mul_B!(Y,A,B)
+
+    # do we get the same result when using the `A*B` form?
+    @fact A*B==Y -->true
     # Y should be extended after the multilpication
     @fact reduce(&, [y1.order for y1 in Y] .== Y[1].order) --> true
     # B should be unchanged
@@ -334,7 +335,7 @@ facts("Matrix multiplication for Taylor1") do
     Y=A*B1[:,1]
     y2=sum(Y)
     # Sometimes this fails due to a small numerical error
-    @fact abs(y1-y2) < tol1 --> true
+    @fact abs(y1-y2) < n1*(eps(y1)+eps(y2)) --> true
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -335,9 +335,17 @@ facts("Matrix multiplication for Taylor1") do
         y1=sum(Y).coeffs[1]
         Y=A*B1[:,1]
         y2=sum(Y)
-        # Sometimes this fails due to a small numerical error
+
+        # There is a small numerical error when comparing the generic
+        # multiplication and the specialized version
         @fact abs(y1-y2) < n1*(eps(y1)+eps(y2)) --> true
+
+        @fact_throws DimensionMismatch A_mul_B!(Y,A[:,1:end-1],B)
+        @fact_throws DimensionMismatch A_mul_B!(Y,A[1:end-1,:],B)
+        @fact_throws DimensionMismatch A_mul_B!(Y,A,B[1:end-1])
+        @fact_throws DimensionMismatch A_mul_B!(Y[1:end-1],A,B)
     end
+
 end
 
 


### PR DESCRIPTION
This greatly improves the performance of multiplying `Vector{Taylor1{T}}` by `Matrix{T}`.  I have to admit that there is a small numerical error of the order `10*eps` when compared to the original `Base.A_mul_B!` but I can't quite locate the source of this inconsistency.  It only shows up for particular arguments, so tests pass most of the time.  Perhaps someone should take a closer look before merging this.  The tests are failing for that reason.