### PR TITLE
Taylor1 functions

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -39,6 +39,9 @@ log
 sin
 cos
 tan
+asin
+acos
+atan
 abs
 ```
 
@@ -60,5 +63,8 @@ expHomogCoef
 logHomogCoef
 sincosHomogCoef
 tanHomogCoef
+asinHomogCoef
+acosHomogCoef
+atanHomogsCoef
 A_mul_B!
 ```

--- a/src/Taylor1.jl
+++ b/src/Taylor1.jl
@@ -691,6 +691,9 @@ function logHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, coeffs::Array{T,1})
     coefhomog
 end
 
+
+### TRIGONOMETRIC FUNCTIONS ###
+
 ## Sin ## 
 doc"""
     sin(a)
@@ -700,6 +703,7 @@ Return the Taylor expansion of $\sin(a)$, of order `a.order`, for
 
 For details on making the Taylor expansion, see [`TaylorSeries.sincosHomogCoef`](@ref).
 """
+
 sin(a::Taylor1) = sincos(a)[1]
 
 ## Cos ## 
@@ -812,6 +816,74 @@ function tanHomogCoef{T<:Number}(kcoef::Int,ac::Array{T,1},coeffst2::Array{T,1})
         coefhomog += (kcoef-i)*ac[kcoef-i+1]*coeffst2[i+1]
     end
     @inbounds coefhomog = ac[kcoef+1] + coefhomog/kcoef
+    coefhomog
+end
+
+### INVERSE TRIGONOMETRIC FUNCTIONS ### 
+
+## Arcsin ##
+function asin(a::Taylor1)
+    @inbounds aux = asin( a.coeffs[1] )
+    r = sqrt(1 - a^2).coeffs
+    T = promote_type(typeof(aux),typeof(r[1]))
+    ac = convert(Array{T,1}, a.coeffs)
+    coeffs = zeros(ac)
+    @inbounds coeffs[1] = aux
+    @inbounds for k in 1:a.order
+        coeffs[k+1] = asinHomogCoef(k , ac, r, coeffs)
+    end
+    Taylor1( coeffs, a.order )
+end
+
+# Homogeneous coefficients for arcsin
+function asinHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, coeffs::Array{T,1})
+    kcoef == 0 && return asin( ac[1] )
+    coefhomog = zero(T)
+    @inbounds for i in 1:kcoef-1
+        coefhomog += (kcoef-i) * r_f[i+1] * coeffs[kcoef-i+1]
+    end
+    @inbounds coefhomog = (ac[kcoef+1] - coefhomog/kcoef) / r_f[1]
+    # r_f[1] = √(1 - f_0^2)
+    coefhomog
+end
+
+## Arccos ## 
+function acos(a::Taylor1)
+    @inbounds aux = acos( a.coeffs[1] )
+    r = sqrt(1 - a^2).coeffs
+    T = promote_type(typeof(aux),typeof(r[1]))
+    ac = convert(Array{T,1}, a.coeffs)
+    coeffs = zeros(ac)
+    @inbounds coeffs[1] = aux
+    @inbounds for k in 1:a.order
+        coeffs[k+1] = -asinHomogCoef(k , ac, r, coeffs)
+    end
+    Taylor1( coeffs, a.order )
+end
+
+## Arctan
+function atan(a::Taylor1)
+    @inbounds aux = atan( a.coeffs[1] )
+    r = (1 + a^2).coeffs
+    T = promote_type(typeof(aux),typeof(r[1]))
+    ac = convert(Array{T,1}, a.coeffs)
+    coeffs = zeros(ac)
+    @inbounds coeffs[1] = aux
+    @inbounds for k in 1:a.order
+        coeffs[k+1] = atanHomogCoef(k , ac, r, coeffs)
+    end
+    Taylor1( coeffs, a.order )
+end
+
+# Homogeneous coefficients for arctan
+function atanHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, coeffs::Array{T,1})
+    kcoef == 0 && return atan( ac[1] )
+    coefhomog = zero(T)
+    @inbounds for i in 1:kcoef-1
+        coefhomog += (kcoef-i) * r_f[i+1] * coeffs[kcoef-i+1]
+    end
+    @inbounds coefhomog = (ac[kcoef+1] - coefhomog/kcoef) / r_f[1]
+    # r_f[1] = (1 - f_0^2)
     coefhomog
 end
 

--- a/src/Taylor1.jl
+++ b/src/Taylor1.jl
@@ -823,6 +823,14 @@ end
 
 
 ## Arcsin ##
+doc"""
+    asin(a)
+
+Return the Taylor expansion of $\arcsin(a)$, of order `a.order`, for
+`a::Taylor1` polynomial.
+
+For details on making the Taylor expansion, see [`TaylorSeries.asinHomogCoef`](@ref).
+"""
 function asin(a::Taylor1)
     @inbounds aux = asin( a.coeffs[1] )
     T = typeof(aux)
@@ -837,6 +845,21 @@ function asin(a::Taylor1)
 end
 
 # Homogeneous coefficients for arcsin
+doc"""
+    asinHomogCoef(kcoef, ac, r_f,coeffs)
+
+Compute the `k-th` expansion coefficient of $c = \arcsin{a}$ given by
+
+\begin{equation*}
+s_k = \frac{1}{ \sqrt{1 - a_0^2} } \big( a_k - \frac{1}{k} \sum_{j=1}^{k-1} j r_{k-j} s_j \big),
+\end{equation*}
+
+with $a$ a `Taylor1` polynomial and $r = \sqrt{1 - a^2}$.
+
+Inputs are the `kcoef`-th coefficient, the vector of the expansion coefficients
+`ac` of `a`, the already calculated expansion coefficients `r_f`
+of $\sqrt{1 - a^2}$, and the previews coefficients `coeffs` of `asinHomogCoef`.
+"""
 function asinHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, coeffs::Array{T,1})
     kcoef == 0 && return asin( ac[1] )
     coefhomog = zero(T)
@@ -848,6 +871,14 @@ function asinHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, c
 end
 
 ## Arccos ## 
+doc"""
+    acos(a)
+
+Return the Taylor expansion of $\arccos(a)$, of order `a.order`, for
+`a::Taylor1` polynomial.
+
+For details on making the Taylor expansion, see [`TaylorSeries.acosHomogCoef`](@ref).
+"""
 function acos(a::Taylor1)
     @inbounds aux = asin( a.coeffs[1] )
     T = typeof(aux)
@@ -863,6 +894,21 @@ function acos(a::Taylor1)
 end
 
 # Homogeneous coefficients for arccos
+doc"""
+    acosHomogCoef(kcoef, ac, r_f, coeffs)
+
+Compute the `k-th` expansion coefficient of $c = \arccos{a}$ given by
+
+\begin{equation*}
+c_k = - \frac{1}{ \sqrt{1 - a_0^2} } \big( a_k - \frac{1}{k} \sum_{j=1}^{k-1} j r_{k-j} c_j \big),
+\end{equation*}
+
+with $a$ a `Taylor1` polynomial and $r = \sqrt{1 - a^2}$.
+
+Inputs are the `kcoef`-th coefficient, the vector of the expansion coefficients
+`ac` of `a`, the already calculated expansion coefficients `r_f`
+of $\sqrt{1 - a^2}$, and the previews coefficients `coeffs` of `acosHomogCoef`.
+"""
 function acosHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, coeffs::Array{T,1})
     kcoef == 0 && return asin( ac[1] )
     coefhomog = zero(T)
@@ -873,7 +919,16 @@ function acosHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, c
     coefhomog
 end
 
+
 ## Arctan
+doc"""
+    atan(a)
+
+Return the Taylor expansion of $\arctan(a)$, of order `a.order`, for
+`a::Taylor1` polynomial.
+
+For details on making the Taylor expansion, see [`TaylorSeries.atanHomogCoef`](@ref).
+"""
 function atan(a::Taylor1)
     @inbounds aux = atan( a.coeffs[1] )
     T = typeof(aux)
@@ -888,6 +943,21 @@ function atan(a::Taylor1)
 end
 
 # Homogeneous coefficients for arctan
+doc"""
+    atanHomogCoef(kcoef, ac, r_f, coeffs)
+
+Compute the `k-th` expansion coefficient of $c = \arctan{a}$ given by
+
+\begin{equation*}
+t_k = \frac{1}{1 + a_0^2 }(a_k - \frac{1}{k} \sum_{j=1}^{k-1} j r_{k-j} t_j) ,
+\end{equation*}
+
+with $a$ a `Taylor1` polynomial and $r = 1 + a^2$.
+
+Inputs are the `kcoef`-th coefficient, the vector of the expansion coefficients
+`ac` of `a`, the already calculated expansion coefficients `r_f`
+of $1 + a^2$, and the previews coefficients `coeffs` of `atanHomogCoef`.
+"""
 function atanHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, coeffs::Array{T,1})
     kcoef == 0 && return atan( ac[1] )
     coefhomog = zero(T)

--- a/src/Taylor1.jl
+++ b/src/Taylor1.jl
@@ -848,7 +848,7 @@ end
 doc"""
     asinHomogCoef(kcoef, ac, r_f,coeffs)
 
-Compute the `k-th` expansion coefficient of $c = \arcsin{a}$ given by
+Compute the `k-th` expansion coefficient of $s = \arcsin(a)$ given by
 
 \begin{equation*}
 s_k = \frac{1}{ \sqrt{1 - a_0^2} } \big( a_k - \frac{1}{k} \sum_{j=1}^{k-1} j r_{k-j} s_j \big),
@@ -858,7 +858,7 @@ with $a$ a `Taylor1` polynomial and $r = \sqrt{1 - a^2}$.
 
 Inputs are the `kcoef`-th coefficient, the vector of the expansion coefficients
 `ac` of `a`, the already calculated expansion coefficients `r_f`
-of $\sqrt{1 - a^2}$, and the previews coefficients `coeffs` of `asinHomogCoef`.
+of $r$ (see above), and the previews coefficients `coeffs` of `asinHomogCoef`.
 """
 function asinHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, coeffs::Array{T,1})
     kcoef == 0 && return asin( ac[1] )
@@ -897,7 +897,7 @@ end
 doc"""
     acosHomogCoef(kcoef, ac, r_f, coeffs)
 
-Compute the `k-th` expansion coefficient of $c = \arccos{a}$ given by
+Compute the `k-th` expansion coefficient of $c = \arccos(a)$ given by
 
 \begin{equation*}
 c_k = - \frac{1}{ \sqrt{1 - a_0^2} } \big( a_k - \frac{1}{k} \sum_{j=1}^{k-1} j r_{k-j} c_j \big),
@@ -907,7 +907,7 @@ with $a$ a `Taylor1` polynomial and $r = \sqrt{1 - a^2}$.
 
 Inputs are the `kcoef`-th coefficient, the vector of the expansion coefficients
 `ac` of `a`, the already calculated expansion coefficients `r_f`
-of $\sqrt{1 - a^2}$, and the previews coefficients `coeffs` of `acosHomogCoef`.
+of $r$ (see above), and the previews coefficients `coeffs` of `acosHomogCoef`.
 """
 function acosHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, coeffs::Array{T,1})
     kcoef == 0 && return asin( ac[1] )
@@ -946,7 +946,7 @@ end
 doc"""
     atanHomogCoef(kcoef, ac, r_f, coeffs)
 
-Compute the `k-th` expansion coefficient of $c = \arctan{a}$ given by
+Compute the `k-th` expansion coefficient of $c = \arctan(a)$ given by
 
 \begin{equation*}
 t_k = \frac{1}{1 + a_0^2 }(a_k - \frac{1}{k} \sum_{j=1}^{k-1} j r_{k-j} t_j) ,
@@ -956,7 +956,7 @@ with $a$ a `Taylor1` polynomial and $r = 1 + a^2$.
 
 Inputs are the `kcoef`-th coefficient, the vector of the expansion coefficients
 `ac` of `a`, the already calculated expansion coefficients `r_f`
-of $1 + a^2$, and the previews coefficients `coeffs` of `atanHomogCoef`.
+of $r$ (see above), and the previews coefficients `coeffs` of `atanHomogCoef`.
 """
 function atanHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, coeffs::Array{T,1})
     kcoef == 0 && return atan( ac[1] )

--- a/src/Taylor1.jl
+++ b/src/Taylor1.jl
@@ -821,16 +821,17 @@ end
 
 ### INVERSE TRIGONOMETRIC FUNCTIONS ### 
 
+
 ## Arcsin ##
 function asin(a::Taylor1)
     @inbounds aux = asin( a.coeffs[1] )
-    r = sqrt(1 - a^2).coeffs
-    T = promote_type(typeof(aux),typeof(r[1]))
+    T = typeof(aux)
     ac = convert(Array{T,1}, a.coeffs)
+    rc = sqrt(one(T) - a^2).coeffs
     coeffs = zeros(ac)
     @inbounds coeffs[1] = aux
     @inbounds for k in 1:a.order
-        coeffs[k+1] = asinHomogCoef(k , ac, r, coeffs)
+        coeffs[k+1] = asinHomogCoef(k, ac, rc, coeffs)
     end
     Taylor1( coeffs, a.order )
 end
@@ -843,20 +844,19 @@ function asinHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, c
         coefhomog += (kcoef-i) * r_f[i+1] * coeffs[kcoef-i+1]
     end
     @inbounds coefhomog = (ac[kcoef+1] - coefhomog/kcoef) / r_f[1]
-    # r_f[1] = √(1 - f_0^2)
     coefhomog
 end
 
 ## Arccos ## 
 function acos(a::Taylor1)
     @inbounds aux = asin( a.coeffs[1] )
-    r = sqrt(1 - a^2).coeffs
-    T = promote_type(typeof(aux),typeof(r[1]))
+    T = typeof(aux)
     ac = convert(Array{T,1}, a.coeffs)
+    rc = sqrt(one(T) - a^2).coeffs
     coeffs = zeros(ac)
     @inbounds coeffs[1] = aux 
     @inbounds for k in 1:a.order
-        coeffs[k+1] = asinHomogCoef(k , ac, r, coeffs)
+        coeffs[k+1] = asinHomogCoef(k , ac, rc, coeffs)
     end
     @inbounds coeffs[1] = -acos( a.coeffs[1] ) 
     Taylor1( -coeffs, a.order )
@@ -870,21 +870,19 @@ function acosHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, c
         coefhomog += (kcoef-i) * r_f[i+1] * coeffs[kcoef-i+1] 
     end
     @inbounds coefhomog = -(ac[kcoef+1] - coefhomog/kcoef) / r_f[1]
-    # r_f[1] = √(1 - f_0^2)
     coefhomog
 end
 
 ## Arctan
 function atan(a::Taylor1)
     @inbounds aux = atan( a.coeffs[1] )
-    r = (1 + a^2).coeffs
-    T = promote_type(typeof(aux),typeof(r[1]))
+    T = typeof(aux)
+    rc = (one(T) + a^2).coeffs
     ac = convert(Array{T,1}, a.coeffs)
-    r  = convert(Array{T,1}, r)
     coeffs = zeros(ac)
     @inbounds coeffs[1] = aux
     @inbounds for k in 1:a.order
-        coeffs[k+1] = atanHomogCoef(k , ac, r, coeffs)
+        coeffs[k+1] = atanHomogCoef(k , ac, rc, coeffs)
     end
     Taylor1( coeffs, a.order )
 end
@@ -897,7 +895,6 @@ function atanHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, r_f::Array{T,1}, c
         coefhomog += (kcoef-i) * r_f[i+1] * coeffs[kcoef-i+1]
     end
     @inbounds coefhomog = (ac[kcoef+1] - coefhomog/kcoef) / r_f[1]
-    # r_f[1] = (1 - f_0^2)
     coefhomog
 end
 

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -24,7 +24,7 @@ import Base: zero, one, zeros, ones, isinf, isnan,
     convert, promote_rule, promote, eltype, length, show,
     real, imag, conj, ctranspose,
     rem, mod, mod2pi, abs, gradient,
-    sqrt, exp, log, sin, cos, tan, A_mul_B!
+sqrt, exp, log, sin, cos, tan, asin, acos, atan, A_mul_B!
 
 export Taylor1, TaylorN, HomogeneousPolynomial
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,13 +82,6 @@ facts("Tests for Taylor1 expansions") do
 
     @fact log(exp(tsquare)) == tsquare  --> true
     @fact exp(log(1-tsquare)) == 1-tsquare  --> true
-    # inverse trigonometrics are not yet passing
-    @fact asin(sin(tsquare)) == tsquare --> true
-    @fact sin(asin(tsquare)) == tsquare --> true
-    @fact acos(cos(tsquare)) == tsquare --> true
-    @fact cos(acos(tsquare)) == tsquare --> true
-    @fact tan(atan(tsquare)) == tsquare --> true
-    @fact atan(tan(tsquare)) == tsquare --> true
     @fact log((1-t)^2) == 2*log(1-t)  --> true
     @fact real(exp(tim)) == cos(t)  --> true
     @fact imag(exp(tim)) == sin(t)  --> true
@@ -102,6 +95,12 @@ facts("Tests for Taylor1 expansions") do
     @fact evaluate(exp(Taylor1([0,1],17)),1.0) == 1.0*e  --> true
     @fact evaluate(exp(Taylor1([0,1],1))) == 1.0  --> true
     @fact evaluate(exp(t),t^2) == exp(t^2)  --> true
+    
+    @fact sin(asin(tsquare)) == tsquare --> true
+    @fact tan(atan(tsquare)) == tsquare --> true
+    @fact atan(tan(tsquare)) == tsquare --> true
+    @fact asin(t) + acos(t) == pi/2 --> true 
+    @fact derivative(acos(t)) == - 1/sqrt(1-t^2) --> true
 
     @fact derivative(5, exp(ta(1.0))) == exp(1.0)  --> true
     @fact derivative(3, exp(ta(1.0pi))) == exp(1.0pi)  --> true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,6 +82,13 @@ facts("Tests for Taylor1 expansions") do
 
     @fact log(exp(tsquare)) == tsquare  --> true
     @fact exp(log(1-tsquare)) == 1-tsquare  --> true
+    # inverse trigonometrics are not yet passing
+    @fact asin(sin(tsquare)) == tsquare --> true
+    @fact sin(asin(tsquare)) == tsquare --> true
+    @fact acos(cos(tsquare)) == tsquare --> true
+    @fact cos(acos(tsquare)) == tsquare --> true
+    @fact tan(atan(tsquare)) == tsquare --> true
+    @fact atan(tan(tsquare)) == tsquare --> true
     @fact log((1-t)^2) == 2*log(1-t)  --> true
     @fact real(exp(tim)) == cos(t)  --> true
     @fact imag(exp(tim)) == sin(t)  --> true


### PR DESCRIPTION
Inverse trigonometric functions `asin`, `acos`, `atan` were added for `Taylor1.jl`. 

Although the recurrence formula I used is correct, there are some problems in obtaining this expansions because an auxiliary expansion `r(x) = sqrt(1 - a^2)` is used for `asin` and `acos`. 

Notice that if `a.coeffs[1] = 1`, then `1 / r.coeffs[1] = Inf`, which is causing trouble when calculating the `HomogCoefs`.

`atan` works perfectly in the tests I did, where `atan(tan(a)) = a = tan(atan(a)) ` with `a::Taylor1`.