### PR TITLE
Change .travis.yml to support Julia 0.4, 0.5 (release) and 0.6 (nightly)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 
 julia:
+    - 0.4
     - release
     - nightly
 


### PR DESCRIPTION
This adds 0.4 to travis to also test this version of Julia, as long as we need it.