### PR TITLE
Explicit method for `Taylor1{Rational{S}}` division by a `Real` or `Complex`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 
 julia:
     - 0.4
-    - release
+    - 0.5
     - nightly
 
 notifications:

--- a/src/Taylor1.jl
+++ b/src/Taylor1.jl
@@ -251,6 +251,14 @@ function mulHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, bc::Array{T,1})
 end
 
 ## Division ##
+function /{T<:Integer, S<:Union{Real,Complex}}(a::Taylor1{Rational{T}},b::S)
+    @inbounds aux = a.coeffs[1] * b
+    v = Array(typeof(aux), length(a.coeffs))
+    @simd for i in eachindex(v)
+        @inbounds v[i] = a.coeffs[i]/b
+    end
+    Taylor1(v, a.order)
+end
 /{T<:Real}(a::Taylor1, b::T) = a * inv(b)
 /{T<:Complex}(a::Taylor1, b::T) = a * inv(b)
 doc"""

--- a/src/Taylor1.jl
+++ b/src/Taylor1.jl
@@ -252,10 +252,10 @@ end
 
 ## Division ##
 function /{T<:Integer, S<:Union{Real,Complex}}(a::Taylor1{Rational{T}},b::S)
-    @inbounds aux = a.coeffs[1] * b
-    v = Array(typeof(aux), length(a.coeffs))
+    R = typeof( a.coeffs[1] // b)
+    v = Array(R, length(a.coeffs))
     @simd for i in eachindex(v)
-        @inbounds v[i] = a.coeffs[i]/b
+        @inbounds v[i] = a.coeffs[i] // b
     end
     Taylor1(v, a.order)
 end

--- a/src/Taylor1.jl
+++ b/src/Taylor1.jl
@@ -45,7 +45,6 @@ Taylor1{T<:Number}(x::Taylor1{T}) = x
 Taylor1{T<:Number}(coeffs::Array{T,1}, order::Int) = Taylor1{T}(coeffs, order)
 Taylor1{T<:Number}(coeffs::Array{T,1}) = Taylor1{T}(coeffs, length(coeffs)-1)
 Taylor1{T<:Number}(x::T, order::Int) = Taylor1{T}([x], order)
-# Taylor1{T<:Number}(x::T) = Taylor1{T}([x], 0)
 
 # Shortcut to define Taylor1 independent variables
 """
@@ -904,10 +903,10 @@ function acos(a::Taylor1)
     coeffs = zeros(ac)
     @inbounds coeffs[1] = aux
     @inbounds for k in 1:a.order
-        coeffs[k+1] = asinHomogCoef(k , ac, rc, coeffs)
+        coeffs[k+1] = acosHomogCoef(k, ac, rc, coeffs)
     end
-    @inbounds coeffs[1] = -acos( a.coeffs[1] )
-    Taylor1( -coeffs, a.order )
+    @inbounds coeffs[1] = acos( a.coeffs[1] )
+    Taylor1( coeffs, a.order )
 end
 
 # Homogeneous coefficients for arccos
@@ -928,13 +927,8 @@ of $r$ (see above), and the already calculated expansion coefficients
 `coeffs` of `acos(a)`.
 """
 function acosHomogCoef{T<:Number}(kcoef::Int, ac::Array{T,1}, rc::Array{T,1}, coeffs::Array{T,1})
-    kcoef == 0 && return asin( ac[1] )
-    coefhomog = zero(T)
-    @inbounds for i in 1:kcoef-1
-        coefhomog += (kcoef-i) * rc[i+1] * coeffs[kcoef-i+1]
-    end
-    @inbounds coefhomog = -(ac[kcoef+1] - coefhomog/kcoef) / rc[1]
-    coefhomog
+    kcoef == 0 && return acos( ac[1] )
+    asinHomogCoef(kcoef, -ac, rc, coeffs)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,9 +21,12 @@ facts("Tests for Taylor1 expansions") do
     @fact get_coeff(Taylor1(Complex128,3),1) == complex(1.0,0.0) --> true
     @fact eltype(convert(Taylor1{Complex128},ot)) == Complex128  --> true
     @fact eltype(convert(Taylor1{Complex128},1)) == Complex128  --> true
+    @fact convert(Taylor1{Int},[0,2]) == 2*t  --> true
     @fact convert(Taylor1{Complex{Int}},[0,2]) == (2+0im)*t  --> true
     @fact convert(Taylor1{BigFloat},[0.0, 1.0]) == ta(big(0.0))  --> true
+    @fact promote(t,Taylor1(1.0,0)) == (ta(0.0),ot)  --> true
     @fact promote(0,Taylor1(1.0,0)) == (zt,ot)  --> true
+    @fact eltype(promote(ta(0),zeros(Int,2))[2]) == Int  --> true
     @fact eltype(promote(ta(0.0),zeros(Int,2))[2]) == Float64  --> true
     @fact eltype(promote(0,Taylor1(ot))[1]) == Float64  --> true
     @fact eltype(promote(1.0+im, zt)[1]) == Complex{Float64}  --> true
@@ -34,6 +37,8 @@ facts("Tests for Taylor1 expansions") do
     @fact eltype(TaylorSeries.fixshape(zt,Taylor1([1.0]))[1]) == Float64  --> true
     @fact TaylorSeries.firstnonzero(t) == 1  --> true
     @fact TaylorSeries.firstnonzero(zt) == zt.order+1  --> true
+    @fact isinf(Taylor1([typemax(1.0)])) --> true
+    @fact isnan(Taylor1([typemax(1.0), NaN])) --> true
 
     @fact t == Taylor1(ta(0),15)  --> true
     @fact ot == 1  --> true
@@ -114,6 +119,7 @@ facts("Tests for Taylor1 expansions") do
     @fact - sinh(t) + cosh(t) == exp(-t) --> true
     @fact  sinh(t) + cosh(t) == exp(t) --> true
     @fact evaluate(- sinh(t)^2 + cosh(t)^2 , rand()) == 1 --> true #works in an eps() difference, but ideally it should return a 1 + 𝒪(t¹⁶) Taylor.
+    @fact evaluate(- sinh(t)^2 + cosh(t)^2 , 0) == 1 --> true #works in an eps() difference, but ideally it should return a 1 + 𝒪(t¹⁶) Taylor.
     @fact tanh(t + 0im) == -1im * tan(t*1im) --> true
     @fact  evaluate(tanh(t/2),1.5) == evaluate(sinh(t) / (cosh(t) + 1),1.5) --> true
     @fact cosh(t) == real(cos(im*t)) --> true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,15 @@ facts("Tests for Taylor1 expansions") do
     @fact ((1-t)^(1//4)).coeffs[15] == -4188908511//549755813888  --> true
     @fact abs(((1+t)^3.2).coeffs[14] + 5.4021062656e-5) < tol1  --> true
 
+    trational = ta(0//1)
+    @fact eltype(trational) --> Rational{Int}
+    @fact trational + 1//3 == Taylor1([1//3,1],15) --> true
+    @fact complex(3,1)*trational^2 ==
+        Taylor1([0//1,0//1,complex(3,1)//1],15) --> true
+    @fact trational^2/3 == Taylor1([0//1,0//1,1//3],15) --> true
+    @fact trational^3/complex(7,1) ==
+        Taylor1([0,0,0,complex(7//50,-1//50)],15) --> true
+
     @fact isapprox( rem(4.1 + t,4).coeffs[1], (0.1 + t).coeffs[1] )  --> true
     @fact isapprox( mod(4.1 + t,4).coeffs[1], (0.1 + t).coeffs[1] )  --> true
     @fact isapprox( mod2pi(2pi+0.1+t).coeffs[1],(0.1 + t).coeffs[1])  --> true
@@ -106,10 +115,10 @@ facts("Tests for Taylor1 expansions") do
     @fact  sinh(t) + cosh(t) == exp(t) --> true
     @fact evaluate(- sinh(t)^2 + cosh(t)^2 , rand()) == 1 --> true #works in an eps() difference, but ideally it should return a 1 + 𝒪(t¹⁶) Taylor.
     @fact tanh(t + 0im) == -1im * tan(t*1im) --> true
-    @fact  evaluate(tanh(t/2),1.5) == evaluate(sinh(t) / (cosh(t) + 1),1.5) --> true 
+    @fact  evaluate(tanh(t/2),1.5) == evaluate(sinh(t) / (cosh(t) + 1),1.5) --> true
     @fact cosh(t) == real(cos(im*t)) --> true
     @fact sinh(t) == imag(sin(im*t)) --> true
-    
+
     v = [sin(t), exp(-t)]
     @fact evaluate(v) == [0.0, 1.0]  --> true
     @fact evaluate(v, complex(0.0,0.2)) ==


### PR DESCRIPTION
This makes that dividing a Taylor1{Rational{S}} by an integer
returns a Taylor1{Rational{S}}; up to now, it was returning a
Taylor1{Float64}