### PR TITLE
Add mod, rem, mod2pi for mixtures of Taylor1 and TaylorN

### DIFF
--- a/src/Taylor1.jl
+++ b/src/Taylor1.jl
@@ -354,10 +354,15 @@ end
 ## Division functions: rem and mod
 for op in (:mod, :rem)
     @eval begin
-        function ($op){T<:Real, S<:Real}(a::Taylor1{T}, x::S)
+        function ($op){T<:Real}(a::Taylor1{T}, x::T)
             coeffs = copy(a.coeffs)
             @inbounds coeffs[1] = ($op)(a.coeffs[1], x)
             return Taylor1(coeffs, a.order)
+        end
+        function ($op){T<:Real, S<:Real}(a::Taylor1{T}, x::S)
+            R = promote_type(T,S)
+            a = convert(Taylor1{R}, a)
+            return ($op)(a, convert(R,x))
         end
     end
 end

--- a/src/TaylorN.jl
+++ b/src/TaylorN.jl
@@ -657,7 +657,29 @@ for op in (:mod, :rem)
             coeffs = copy(a.coeffs)
             y = ($op)(a.coeffs[1].coeffs[1], x)
             coeffs[1] = HomogeneousPolynomial(y)
-            return TaylorN{T}( coeffs, a.order )
+            return TaylorN( coeffs, a.order )
+        end
+        @inbounds function ($op){T<:Real}(a::TaylorN{Taylor1{T}}, x::T)
+            coeffs = copy(a.coeffs)
+            y = ($op)(a.coeffs[1].coeffs[1], x)
+            coeffs[1] = HomogeneousPolynomial(y)
+            return TaylorN( coeffs, a.order )
+        end
+        @inbounds function ($op){T<:Real,S<:Real}(a::TaylorN{Taylor1{T}}, x::S)
+            R = promote_type(T,S)
+            a = convert(TaylorN{Taylor1{R}}, a)
+            return ($op)(a, convert(R,x))
+        end
+        @inbounds function ($op){T<:Real}(a::Taylor1{TaylorN{T}}, x::T)
+            coeffs = copy(a.coeffs)
+            y = ($op)(a.coeffs[1], x)
+            coeffs[1] = y
+            return Taylor1( coeffs, a.order )
+        end
+        @inbounds function ($op){T<:Real,S<:Real}(a::Taylor1{TaylorN{T}}, x::S)
+            R = promote_type(T,S)
+            a = convert(Taylor1{TaylorN{R}}, a)
+            return ($op)(a, convert(R,x))
         end
     end
 end
@@ -666,7 +688,19 @@ function mod2pi{T<:Real}(a::TaylorN{T})
     coeffs = copy(a.coeffs)
     @inbounds y = mod2pi(a.coeffs[1].coeffs[1])
     @inbounds coeffs[1] = HomogeneousPolynomial(y)
-    return TaylorN{T}( coeffs, a.order )
+    return TaylorN( coeffs, a.order )
+end
+function mod2pi{T<:Real}(a::TaylorN{Taylor1{T}})
+    coeffs = copy(a.coeffs)
+    @inbounds y = mod2pi(a.coeffs[1].coeffs[1])
+    @inbounds coeffs[1] = HomogeneousPolynomial(y)
+    return TaylorN( coeffs, a.order )
+end
+function mod2pi{T<:Real}(a::Taylor1{TaylorN{T}})
+    coeffs = copy(a.coeffs)
+    @inbounds y = mod2pi(a.coeffs[1])
+    @inbounds coeffs[1] = y
+    return Taylor1( coeffs, a.order )
 end
 
 ## abs function ##

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,9 +88,11 @@ facts("Tests for Taylor1 expansions") do
     @fact trational^3/complex(7,1) ==
         Taylor1([0,0,0,complex(7//50,-1//50)],15) --> true
 
-    @fact isapprox( rem(4.1 + t,4).coeffs[1], (0.1 + t).coeffs[1] )  --> true
-    @fact isapprox( mod(4.1 + t,4).coeffs[1], (0.1 + t).coeffs[1] )  --> true
-    @fact isapprox( mod2pi(2pi+0.1+t).coeffs[1],(0.1 + t).coeffs[1])  --> true
+    @fact isapprox( rem(4.1 + t,4).coeffs[1], 0.1 )  --> true
+    @fact isapprox( mod(4.1 + t,4).coeffs[1], 0.1 )  --> true
+    @fact isapprox( rem(1+Taylor1(Int,4),4.0).coeffs[1], 1.0 )  --> true
+    @fact isapprox( mod(1+Taylor1(Int,4),4.0).coeffs[1], 1.0 )  --> true
+    @fact isapprox( mod2pi(2pi+0.1+t).coeffs[1], 0.1 )  --> true
 
     @fact abs(ta(1))  --> ta(1)
     @fact abs(ta(-1.0))  --> -ta(-1.0)
@@ -275,6 +277,8 @@ facts("Tests for HomogeneousPolynomial and TaylorN") do
     @fact (yT/(1-xT)).coeffs[5] == xH^3 * yH  --> true
     @fact mod(1+xT,1) == +xT  --> true
     @fact (rem(1+xT,1)).coeffs[1] == 0  --> true
+    @fact mod(1+xT,1.0) == +xT  --> true
+    @fact (rem(1+xT,1.0)).coeffs[1] == 0  --> true
     @fact abs(1-xT)  --> 1-xT
     @fact abs(-1-xT)  --> 1+xT
     @fact derivative(mod2pi(2pi+yT^3),2) == derivative(yT^3,2)  --> true
@@ -387,6 +391,20 @@ facts("Tests with mixures of Taylor1 and TaylorN") do
     @fact tN1-tN1 == zero(tN1) --> true
     @fact string(t1N*t1N) ==
         "  1.0 x₁² + 𝒪(‖x‖³) + ( 2.0 x₁ + 𝒪(‖x‖³)) t + ( 1.0 + 𝒪(‖x‖³)) t² + 𝒪(t³)" --> true
+
+    @fact mod(tN1+1.125,1.0) == 0.125+tN1  --> true
+    @fact mod(tN1-1.125,2) == 0.875+tN1  --> true
+    @fact (rem(tN1+1.125,1.0)).coeffs[1].coeffs[1] == 0.125 + t --> true
+    @fact (rem(tN1-1.125,2)).coeffs[1].coeffs[1] == -1.125 + t --> true
+    @fact mod2pi(-3pi+tN1).coeffs[1].coeffs[1].coeffs[1] ≈ pi --> true
+    @fact mod2pi(0.125+2pi+tN1).coeffs[1].coeffs[1].coeffs[1] ≈ 0.125 --> true
+    @fact mod(t1N+1.125,1.0) == 0.125+t1N  --> true
+    @fact mod(t1N-1.125,2) == 0.875+t1N  --> true
+    @fact (rem(t1N+1.125,1.0)).coeffs[1] == 0.125 + t1N.coeffs[1] --> true
+    @fact (rem(t1N-1.125,2)).coeffs[1] == -1.125 + t1N.coeffs[1] --> true
+    @fact mod2pi(-3pi+t1N).coeffs[1].coeffs[1].coeffs[1] ≈ pi --> true
+    @fact mod2pi(0.125+2pi+t1N).coeffs[1].coeffs[1].coeffs[1] ≈ 0.125 --> true
+
     @fact convert(Array{Taylor1{TaylorN{Float64}},1}, [tN1, tN1]) ==
         [t1N, t1N] --> true
     @fact convert(Array{Taylor1{TaylorN{Float64}},2}, [tN1 tN1]) ==


### PR DESCRIPTION
This extends the functions `mod`, `rem`, and `mod2pi` to work with `Taylor1{TaylorN{T}}` and `TaylorN{Taylor1{T}}`.