### PR TITLE
Make `index_table` a Vector{Vector{UInt128}}, and add tests

### DIFF
--- a/src/hash_tables.jl
+++ b/src/hash_tables.jl
@@ -15,9 +15,9 @@ and `pos_table`. Internally, these are treated as `const`.
 The $i+1$-th component contains a vector with the vectors of all the possible
 combinations of monomials of a `HomogeneousPolynomial` of order $i$.
 
-    index_table :: Array{Array{Int64,1},1}
+    index_table :: Array{Array{UInt128,1},1}
 
-The $i+1$-th component contains a vector of (hashed) indices that represent
+The $i+1$-th component contains a vector of `UInt128` indices that represent
 the distinct monomials of a `HomogeneousPolynomial` of order (degree) $i$.
 
     size_table :: Array{Int64,1}
@@ -25,15 +25,15 @@ the distinct monomials of a `HomogeneousPolynomial` of order (degree) $i$.
 The $i+1$-th component contains the number of distinct monomials of the
 `HomogeneousPolynomial` of order $i$, equivalent to `length(coeff_table[i])`.
 
-    pos_table :: Array{Dict{Int64,Int64},1}
+    pos_table :: Array{Dict{UInt128,UInt128},1}
 
-The $i+1$-th component maps the hash index to the (lexicographic) position
+The $i+1$-th component maps the `UInt128` index to the (lexicographic) position
 of the corresponding monomial in `coeffs_table`.
 """
 function generate_tables(num_vars, order)
     coeff_table = [generate_index_vectors(num_vars, i) for i in 0:order]
 
-    index_table = Vector{Int}[map(x->in_base(order, x), coeffs) for coeffs in coeff_table]
+    index_table = Vector{UInt128}[map(x->in_base(order, x), coeffs) for coeffs in coeff_table]
 
     pos_table = map(make_inverse_dict, index_table)
     size_table = map(length, index_table)
@@ -84,15 +84,16 @@ end
 """
     in_base(order, v)
 
-Convert vector `v` of non-negative integers to base `order+1`.
+Convert vector `v` of non-negative integers to base `order+1` using
+`UInt128` arithmetic.
 """
 function in_base(order, v)
-    order = order+1
+    order = UInt128(order+1)
 
-    result = 0
+    result = UInt128(0)
 
     for i in v
-        result = result*order + i
+        result = result*order + UInt128(i)
     end
 
     result

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -16,12 +16,19 @@ using Base.Test
     @test typeof(show_params_TaylorN()) == Void
 
     @test TaylorSeries.coeff_table[2][1] == [1,0]
-    @test TaylorSeries.index_table[2][1] == 7
-    @test TaylorSeries.in_base(get_order(),[2,1]) == 15
+    @test TaylorSeries.index_table[2][1] == UInt128(7)
+    @test TaylorSeries.in_base(get_order(),[2,1]) == UInt128(15)
     @test TaylorSeries.pos_table[4][15] == 2
 
     @test get_order() == 6
     @test get_numvars() == 2
+
+    set_variables("δ", order=1, numvars=70)
+    @test TaylorSeries.coeff_table[2][1][1] == 1
+    @test TaylorSeries.coeff_table[2][2][2] == 1
+    @test TaylorSeries.index_table[2][1] === 0x00000000000000200000000000000000
+    @test TaylorSeries.pos_table[2][0x00000000000000000000002000000000] == 33
+    @test TaylorSeries.pos_table[2][0x00000000000000000000000000000001] == 70
 
     x, y = set_variables("x y", order=6)
     @test x.order == 6


### PR DESCRIPTION
This is a small modification addressing [#85]. It simply carries
on the hashing of the vectors of integers in `UInt128` arithmetic.