### PR TITLE
Add jacobian! and hessian! methods and tests

### DIFF
--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -32,7 +32,7 @@ export get_coeff, derivative, integrate,
     show_params_TaylorN,
     get_order, get_numvars,
     set_variables, get_variables,
-    ∇, jacobian, hessian
+    ∇, jacobian, jacobian!, hessian
 
 include("parameters.jl")
 include("hash_tables.jl")

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -32,7 +32,7 @@ export get_coeff, derivative, integrate,
     show_params_TaylorN,
     get_order, get_numvars,
     set_variables, get_variables,
-    ∇, jacobian, jacobian!, hessian
+    ∇, jacobian, jacobian!, hessian, hessian!
 
 include("parameters.jl")
 include("hash_tables.jl")

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -208,4 +208,17 @@ hessian{T<:Number,S<:Number}(f::TaylorN{T}, vals::Array{S,1}) =
     (R = promote_type(T,S); jacobian( gradient(f), vals::Array{R,1}) )
 hessian{T<:Number}(f::TaylorN{T}) = hessian( f, zeros(T, get_numvars()) )
 
+"""
+```
+    hessian!(hes, f)
+    hessian!(hes, f, [vals])
+```
+
+Return the hessian matrix (jacobian of the gradient) of `f::TaylorN`,
+evaluated at the vector `vals`, and write results to `hes`. If `vals` is
+ommited, it is evaluated at zero.
+"""
+hessian!{T<:Number}(hes::Array{T,2}, f::TaylorN{T}, vals::Array{T,1}) = jacobian!(hes, gradient(f), vals)
+hessian!{T<:Number}(hes::Array{T,2}, f::TaylorN{T}) = jacobian!(hes, gradient(f))
+
 ## TODO: Integration...

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -163,6 +163,39 @@ end
 
 """
 ```
+    jacobian!(jac, vf)
+    jacobian!(jac, vf, [vals])
+```
+
+Compute the jacobian matrix of `vf`, a vector of `TaylorN` polynomials
+evaluated at the vector `vals`, and write results to `jac`. If `vals` is ommited, it is evaluated at zero.
+"""
+function jacobian!{T<:Number}(jac::Array{T,2}, vf::Array{TaylorN{T},1})
+    numVars = get_numvars()
+    @assert length(vf) == numVars
+    @assert (numVars, numVars) == size(jac)
+    for comp2 = 1:numVars
+        for comp1 = 1:numVars
+            @inbounds jac[comp1,comp2] = vf[comp1].coeffs[2].coeffs[comp2]
+        end
+    end
+    nothing
+end
+function jacobian!{T<:Number}(jac::Array{T,2}, vf::Array{TaylorN{T},1},vals::Array{T,1})
+    numVars = get_numvars()
+    @assert length(vf) == numVars == length(vals)
+    @assert (numVars, numVars) == size(jac)
+    for comp = 1:numVars
+        @inbounds for nv = 1:numVars
+            jac[nv,comp] = evaluate(derivative(vf[nv], comp), vals)
+        end
+    end
+    nothing
+end
+
+
+"""
+```
     hessian(f)
     hessian(f, [vals])
 ```

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -151,6 +151,18 @@ using Base.Test
     @test hessian(f1^2)/2 == [ [49,0] [0,12] ]
     @test hessian(f1-f2-2*f1*f2) == (hessian(f1-f2-2*f1*f2))'
     @test hessian(f1-f2,[1,-1]) == hessian(g1(xT+1,yT-1)-g2(xT+1,yT-1))
+    hes = Array{Int64}(2, 2)
+    hessian!(hes, f1*f2)
+    @test hes == hessian(f1*f2)
+    @test [xT yT]*hes*[xT, yT] == [ 2*TaylorN((f1*f2).coeffs[3]) ]
+    hessian!(hes, f1^2)
+    @test hes/2 == [ [49,0] [0,12] ]
+    hessian!(hes, f1-f2-2*f1*f2)
+    @test hes == hes'
+    hes1 = hes2 = Array{Int64}(2, 2)
+    hessian!(hes1,f1-f2,[1,-1])
+    hessian!(hes2,g1(xT+1,yT-1)-g2(xT+1,yT-1))
+    @test hes1 == hes2
 
     @test string(-xH) == " - 1 x₁"
     @test string(xT^2) == " 1 x₁² + 𝒪(‖x‖¹⁸)"

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -142,6 +142,11 @@ using Base.Test
     @test gradient(f1) == [ 3*xT^2-4*xT*yT-TaylorN(7,0), 6*yT-2*xT^2 ]
     @test ∇(f2) == [2*xT - 4*xT^3, TaylorN(1,0)]
     @test jacobian([f1,f2], [2,1]) == jacobian( [g1(xT+2,yT+1), g2(xT+2,yT+1)] )
+    jac = Array{Int64}(2, 2)
+    jacobian!(jac, [g1(xT+2,yT+1), g2(xT+2,yT+1)])
+    @test jac == jacobian( [g1(xT+2,yT+1), g2(xT+2,yT+1)] )
+    jacobian!(jac, [f1,f2], [2,1])
+    @test jac == jacobian([f1,f2], [2,1])
     @test [xT yT]*hessian(f1*f2)*[xT, yT] == [ 2*TaylorN((f1*f2).coeffs[3]) ]
     @test hessian(f1^2)/2 == [ [49,0] [0,12] ]
     @test hessian(f1-f2-2*f1*f2) == (hessian(f1-f2-2*f1*f2))'


### PR DESCRIPTION
This PR addresses #88 , namely, adds `jacobian!` methods (i.e., in-place evaluation versions of `jacobian`). Also added corresponding tests, which pass locally in Julia 0.5.