### PR TITLE
Fuse operations and methods for mixed types

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.5
+Compat 0.19.0

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -33,7 +33,7 @@ import Base: zero, one, zeros, ones, isinf, isnan,
     asin, acos, atan, sinh, cosh, tanh,
     reverse, A_mul_B!
 
-export Taylor1, TaylorN, HomogeneousPolynomial, AbstractTaylor
+export Taylor1, TaylorN, HomogeneousPolynomial, AbstractSeries
 
 export get_coeff, derivative, integrate,
     evaluate, evaluate!,

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -19,6 +19,7 @@ using Compat
 
 if VERSION ≤ v"0.6.0-dev"
     import Compat: iszero
+    export iszero
 else
     import Base: iszero
 end

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -15,6 +15,14 @@ or more independent variables.
 """
 module TaylorSeries
 
+using Compat
+
+if VERSION ≤ v"0.6.0-dev"
+    import Compat: iszero
+else
+    import Base: iszero
+end
+
 import Base: ==, +, -, *, /, ^
 
 import Base: zero, one, zeros, ones, isinf, isnan,

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -33,7 +33,7 @@ import Base: zero, one, zeros, ones, isinf, isnan,
     asin, acos, atan, sinh, cosh, tanh,
     reverse, A_mul_B!
 
-export Taylor1, TaylorN, HomogeneousPolynomial
+export Taylor1, TaylorN, HomogeneousPolynomial, AbstractTaylor
 
 export get_coeff, derivative, integrate,
     evaluate, evaluate!,

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -468,10 +468,9 @@ function divfactorization(a1::Taylor1, b1::Taylor1)
     # order of first factorized term; a1 and b1 assumed to be of the same order
     a1nz = findfirst(a1)
     b1nz = findfirst(b1)
+    a1nz = a1nz ≥ 0 ? a1nz : a1.order
+    b1nz = b1nz ≥ 0 ? b1nz : a1.order
     orddivfact = min(a1nz, b1nz)
-    if orddivfact < 0
-        orddivfact = a1.order
-    end
     cdivfact = a1.coeffs[orddivfact+1] / b1.coeffs[orddivfact+1]
 
     # Is the polynomial factorizable?

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -34,8 +34,8 @@ iszero(a::HomogeneousPolynomial) = iszero(a.coeffs)
 
 
 ## zero and one ##
-zero{T<:Number}(a::Taylor1{T}) = Taylor1(zero(a.coeffs[1]), a.order)
-one{T<:Number}(a::Taylor1{T}) = Taylor1(one(a.coeffs[1]), a.order)
+zero(a::Taylor1) = Taylor1(zero(a.coeffs[1]), a.order)
+one(a::Taylor1) = Taylor1(one(a.coeffs[1]), a.order)
 
 
 function zero{T<:Number}(a::HomogeneousPolynomial{T})
@@ -69,11 +69,7 @@ function ones{T<:Number}(a::HomogeneousPolynomial{T}, order::Int)
     v = Array{HomogeneousPolynomial{T}}(order+1)
     @simd for ord in eachindex(v)
         @inbounds num_coeffs = size_table[ord]
-        vT = Array{T}(num_coeffs)
-        @simd for ind in 1:num_coeffs
-            @inbounds vT[ind] = one(a.coeffs[1])
-        end
-        @inbounds v[ord] = HomogeneousPolynomial(vT, ord-1)
+        @inbounds v[ord] = HomogeneousPolynomial(ones(T, num_coeffs), ord-1)
     end
     return v
 end
@@ -81,8 +77,8 @@ end
 ones{T<:Number}(::Type{HomogeneousPolynomial{T}}, order::Int) =
     ones( HomogeneousPolynomial([one(T)], 0), order)
 
-zero{T<:Number}(a::TaylorN{T}) = TaylorN(zero(a.coeffs[1]), a.order)
-one{T<:Number}(a::TaylorN{T}) = TaylorN(one(a.coeffs[1]), a.order)
+zero(a::TaylorN) = TaylorN(zero(a.coeffs[1]), a.order)
+one(a::TaylorN) = TaylorN(one(a.coeffs[1]), a.order)
 
 
 
@@ -352,11 +348,9 @@ end
 ## Division ##
 function /{T<:Integer, S<:RealOrComplex}(a::Taylor1{Rational{T}}, b::S)
     R = typeof( a.coeffs[1] // b)
-    v = Array{R}(length(a.coeffs))
-    @simd for i in eachindex(v)
-        @inbounds v[i] = a.coeffs[i] // b
-    end
-    Taylor1(v, a.order)
+    v = Array{R}(a.order+1)
+    v .= a.coeffs .// b
+    return Taylor1(v, a.order)
 end
 
 for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -30,8 +30,9 @@ end
 ==(a::HomogeneousPolynomial, b::HomogeneousPolynomial) = a.coeffs == b.coeffs
 
 
-iszero(a::HomogeneousPolynomial) = iszero(a.coeffs)
-
+for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
+    @eval iszero(a::$T) = iszero(a.coeffs)
+end
 
 ## zero and one ##
 zero(a::Taylor1) = Taylor1(zero(a.coeffs[1]), a.order)
@@ -84,7 +85,7 @@ one(a::TaylorN) = TaylorN(one(a.coeffs[1]), a.order)
 
 ## Addition and substraction ##
 for f in (:+, :-)
-    dotf = ifelse( f == :+, :.+, :.-)
+    dotf = ifelse( f == :+, :(.+), :(.-))
     for T in (:Taylor1, :TaylorN)
         @eval begin
             ($f){T<:Number,S<:Number}(a::$T{T}, b::$T{S}) = $f(promote(a,b)...)
@@ -112,15 +113,17 @@ for f in (:+, :-)
                 broadcast!($f, v, a.coeffs)
                 return $T(v, a.order)
             end
-            function $f(a::$T, b::RealOrComplex)
-                R = promote_type(eltype(a.coeffs), eltype(b))
+            ($f){T<:Number,S<:Number}(a::$T{T}, b::S) = $f(promote(a,b)...)
+            function $f{T<:Number}(a::$T{T}, b::T)
+                R = eltype(a.coeffs)
                 coeffs = Array{R}(a.order+1)
                 coeffs .= a.coeffs
                 @inbounds coeffs[1] = $f(a.coeffs[1], b)
                 return $T(coeffs, a.order)
             end
-            function $f(b::RealOrComplex, a::$T)
-                R = promote_type(eltype(a.coeffs), eltype(b))
+            ($f){T<:Number,S<:Number}(b::S, a::$T{T}) = $f(promote(b,a)...)
+            function $f{T<:Number}(b::T, a::$T{T})
+                R = eltype(a.coeffs)
                 coeffs = Array{R}(a.order+1)
                 coeffs .= $f(a.coeffs)
                 @inbounds coeffs[1] = $f(b, a.coeffs[1])
@@ -129,9 +132,9 @@ for f in (:+, :-)
         end
     end
     @eval begin
-        ($f){T<:Number,S<:Number}(a::HomogeneousPolynomial{T},
+        ($f){T<:NumberNotSeriesN,S<:NumberNotSeriesN}(a::HomogeneousPolynomial{T},
             b::HomogeneousPolynomial{S}) = $f(promote(a,b)...)
-        function $f{T<:Number}(a::HomogeneousPolynomial{T},
+        function $f{T<:NumberNotSeriesN}(a::HomogeneousPolynomial{T},
                 b::HomogeneousPolynomial{T})
             @assert a.order == b.order
             v = similar(a.coeffs)
@@ -143,7 +146,8 @@ for f in (:+, :-)
             v .= $f(a.coeffs)
             return HomogeneousPolynomial(v, a.order)
         end
-        function ($f){T<:RealOrComplex,S<:RealOrComplex}(
+        #
+        function ($f){T<:NumberNotSeries,S<:NumberNotSeries}(
                 a::TaylorN{Taylor1{T}}, b::Taylor1{S})
             @inbounds aux = $f(a.coeffs[1].coeffs[1], b)
             R = typeof(aux)
@@ -152,14 +156,32 @@ for f in (:+, :-)
             @inbounds coeffs[1] = aux
             return TaylorN(coeffs, a.order)
         end
-        function ($f){T<:RealOrComplex,S<:RealOrComplex}(
-            b::Taylor1{S}, a::TaylorN{Taylor1{T}})
+        function ($f){T<:NumberNotSeries,S<:NumberNotSeries}(
+                b::Taylor1{S}, a::TaylorN{Taylor1{T}})
             @inbounds aux = $f(b, a.coeffs[1].coeffs[1])
             R = typeof(aux)
             coeffs = Array{HomogeneousPolynomial{Taylor1{R}}}(a.order+1)
             coeffs .= $f(a.coeffs)
             @inbounds coeffs[1] = aux
             return TaylorN(coeffs, a.order)
+        end
+        function ($f){T<:NumberNotSeries,S<:NumberNotSeries}(
+                a::Taylor1{TaylorN{T}}, b::TaylorN{S})
+            @inbounds aux = $f(a.coeffs[1], b)
+            R = eltype(aux)
+            coeffs = Array{TaylorN{R}}(a.order+1)
+            coeffs .= a.coeffs
+            @inbounds coeffs[1] = aux
+            return Taylor1(coeffs, a.order)
+        end
+        function ($f){T<:NumberNotSeries,S<:NumberNotSeries}(
+            b::TaylorN{S}, a::Taylor1{TaylorN{T}})
+            @inbounds aux = $f(b, a.coeffs[1])
+            R = eltype(aux)
+            coeffs = Array{TaylorN{R}}(a.order+1)
+            coeffs .= $f(a.coeffs)
+            @inbounds coeffs[1] = aux
+            return Taylor1(coeffs, a.order)
         end
     end
 end
@@ -171,36 +193,38 @@ for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
     @eval begin
         *(a::Bool, b::$T) = *(convert(Int, a), b)
         *(a::$T, b::Bool) = b * a
-        function *(a::RealOrComplex, b::$T)
+        function *{T<:NumberNotSeries}(a::T, b::$T)
             @inbounds aux = a * b.coeffs[1]
             v = Array{typeof(aux)}(length(b.coeffs))
-            @simd for i in eachindex(v)
-                @inbounds v[i] = a * b.coeffs[i]
-            end
+            v .= a .* b.coeffs
             $T(v, b.order)
         end
-        *(b::$T, a::RealOrComplex) = a * b
-        if $T != Taylor1
-            function *{T<:RealOrComplex}(a::Taylor1{T}, b::$T{Taylor1{T}})
-                @inbounds aux = a * b.coeffs[1]
-                S = typeof(aux)
-                coeffs = Array{S}(length(b.coeffs))
-                @simd for i in eachindex(coeffs)
-                    @inbounds coeffs[i] = a * b.coeffs[i]
-                end
-                return $T(coeffs, b.order)
-            end
-            *{T<:RealOrComplex}(b::$T{Taylor1{T}}, a::Taylor1{T}) = a * b
-            function *{T<:RealOrComplex,R<:RealOrComplex}(a::Taylor1{T},
-                    b::$T{Taylor1{R}})
-                S = promote_type(T,R)
-                return convert(Taylor1{S}, a) * convert($T{Taylor1{S}}, b)
-            end
-            *{T<:RealOrComplex,R<:RealOrComplex}(b::$T{Taylor1{T}},
-                a::Taylor1{R}) = a * b
-        end
+        *{T<:NumberNotSeries}(b::$T, a::T) = a * b
     end
 end
+
+for T in (:HomogeneousPolynomial, :TaylorN)
+    @eval begin
+        function *{T<:NumberNotSeries,S<:NumberNotSeries}(a::Taylor1{T}, b::$T{Taylor1{S}})
+            @inbounds aux = a * b.coeffs[1]
+            R = typeof(aux)
+            coeffs = Array{R}(length(b.coeffs))
+            coeffs .= a .* b.coeffs
+            return $T(coeffs, b.order)
+        end
+        *{T<:NumberNotSeries,R<:NumberNotSeries}(b::$T{Taylor1{R}}, a::Taylor1{T}) = a * b
+        function *{T<:NumberNotSeries,S<:NumberNotSeries}(a::$T{T}, b::Taylor1{$T{S}})
+            @inbounds aux = a * b.coeffs[1]
+            R = typeof(aux)
+            coeffs = Array{R}(length(b.coeffs))
+            coeffs .= a .* b.coeffs
+            return Taylor1(coeffs, b.order)
+        end
+        *{T<:NumberNotSeries,S<:NumberNotSeries}(b::Taylor1{$T{S}}, a::$T{T}) = a * b
+    end
+end
+
+
 
 doc"""
 ```
@@ -222,8 +246,8 @@ function *{T<:Number}(a::Taylor1{T}, b::Taylor1{T})
     return Taylor1(coeffs, a.order)
 end
 
-*{T<:Number,S<:Number}(a::TaylorN{T}, b::TaylorN{S}) = *(promote(a,b)...)
-function *{T<:Number}(a::TaylorN{T}, b::TaylorN{T})
+*{T<:NumberNotSeriesN,S<:NumberNotSeriesN}(a::TaylorN{T}, b::TaylorN{S}) = *(promote(a,b)...)
+function *{T<:NumberNotSeriesN}(a::TaylorN{T}, b::TaylorN{T})
     a, b = fixorder(a, b)
     coeffs = zeros(HomogeneousPolynomial{T}, a.order)
 
@@ -237,9 +261,9 @@ function *{T<:Number}(a::TaylorN{T}, b::TaylorN{T})
 end
 
 ## Multiplication ##
-*{T<:Number,S<:Number}(a::HomogeneousPolynomial{T}, b::HomogeneousPolynomial{S}) =
+*{T<:NumberNotSeriesN,S<:NumberNotSeriesN}(a::HomogeneousPolynomial{T}, b::HomogeneousPolynomial{S}) =
     *(promote(a,b)...)
-function *{T<:Number}(a::HomogeneousPolynomial{T}, b::HomogeneousPolynomial{T})
+function *{T<:NumberNotSeriesN}(a::HomogeneousPolynomial{T}, b::HomogeneousPolynomial{T})
     order = a.order + b.order
     # order > get_order() && return HomogeneousPolynomial([a.coeffs[1]], get_order())
     order > get_order() && return HomogeneousPolynomial([zero(a.coeffs[1])], get_order())
@@ -346,7 +370,7 @@ end
 
 
 ## Division ##
-function /{T<:Integer, S<:RealOrComplex}(a::Taylor1{Rational{T}}, b::S)
+function /{T<:Integer, S<:NumberNotSeries}(a::Taylor1{Rational{T}}, b::S)
     R = typeof( a.coeffs[1] // b)
     v = Array{R}(a.order+1)
     v .= a.coeffs .// b
@@ -355,18 +379,37 @@ end
 
 for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
     @eval begin
-        /{T<:RealOrComplex}(a::$T{T}, b::T) = a * inv(b)
-        function /{T<:RealOrComplex,S<:RealOrComplex}(a::$T{T}, b::S)
+        /{T<:NumberNotSeries}(a::$T{T}, b::T) = a * inv(b)
+        function /{T<:NumberNotSeries,S<:NumberNotSeries}(a::$T{T}, b::S)
             R = promote_type(T,S)
             return convert($T{R}, a) * inv(convert(R, b))
         end
-        /{T<:RealOrComplex}(a::$T, b::T) = a * inv(b)
-        if $T != Taylor1
-            /{T<:RealOrComplex,R<:RealOrComplex}(
-                a::$T{Taylor1{T}}, x::Taylor1{R}) = a * inv(x)
+        /{T<:NumberNotSeries}(a::$T, b::T) = a * inv(b)
+    end
+end
+
+for T in (:HomogeneousPolynomial, :TaylorN)
+    @eval begin
+        function /{T<:NumberNotSeries,S<:NumberNotSeries}(
+                b::$T{Taylor1{S}}, a::Taylor1{T})
+            @inbounds aux = b.coeffs[1] / a
+            R = typeof(aux)
+            coeffs = Array{R}(length(b.coeffs))
+            coeffs .= b.coeffs ./ a
+            return $T(coeffs, b.order)
+        end
+        function /{T<:NumberNotSeries,S<:NumberNotSeries}(
+                b::Taylor1{$T{S}}, a::$T{T})
+            @inbounds aux = b.coeffs[1] / a
+            R = typeof(aux)
+            coeffs = Array{R}(length(b.coeffs))
+            coeffs .= b.coeffs ./ a
+            return Taylor1(coeffs, b.order)
         end
     end
 end
+
+
 
 
 doc"""
@@ -396,8 +439,8 @@ function /{R<:Number}(a::Taylor1{R}, b::Taylor1{R})
     Taylor1(coeffs, a.order)
 end
 
-/{T<:Number,S<:Number}(a::TaylorN{T}, b::TaylorN{S}) = /(promote(a,b)...)
-function /{R<:Number}(a::TaylorN{R}, b::TaylorN{R})
+/{T<:NumberNotSeriesN,S<:NumberNotSeriesN}(a::TaylorN{T}, b::TaylorN{S}) = /(promote(a,b)...)
+function /{T<:NumberNotSeriesN}(a::TaylorN{T}, b::TaylorN{T})
     @inbounds b0 = b.coeffs[1].coeffs[1]
     @assert b0 != zero(b0)
     a, b = fixorder(a, b)
@@ -405,8 +448,8 @@ function /{R<:Number}(a::TaylorN{R}, b::TaylorN{R})
     # orddivfact, cdivfact = divfactorization(a, b)
     b0 = inv(b0)
     @inbounds cdivfact = a.coeffs[1] * b0
-    T = eltype(cdivfact)
-    coeffs = zeros(HomogeneousPolynomial{T}, a.order)
+    R = eltype(cdivfact)
+    coeffs = zeros(HomogeneousPolynomial{R}, a.order)
     @inbounds coeffs[1] = cdivfact
 
     for ord in eachindex(coeffs)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -150,7 +150,7 @@ for f in (:+, :-)
         function ($f){T<:NumberNotSeries,S<:NumberNotSeries}(
                 a::TaylorN{Taylor1{T}}, b::Taylor1{S})
             @inbounds aux = $f(a.coeffs[1].coeffs[1], b)
-            R = typeof(aux)
+            R = eltype(aux)
             coeffs = Array{HomogeneousPolynomial{Taylor1{R}}}(a.order+1)
             coeffs .= a.coeffs
             @inbounds coeffs[1] = aux
@@ -159,7 +159,7 @@ for f in (:+, :-)
         function ($f){T<:NumberNotSeries,S<:NumberNotSeries}(
                 b::Taylor1{S}, a::TaylorN{Taylor1{T}})
             @inbounds aux = $f(b, a.coeffs[1].coeffs[1])
-            R = typeof(aux)
+            R = eltype(aux)
             coeffs = Array{HomogeneousPolynomial{Taylor1{R}}}(a.order+1)
             coeffs .= $f(a.coeffs)
             @inbounds coeffs[1] = aux
@@ -175,7 +175,7 @@ for f in (:+, :-)
             return Taylor1(coeffs, a.order)
         end
         function ($f){T<:NumberNotSeries,S<:NumberNotSeries}(
-            b::TaylorN{S}, a::Taylor1{TaylorN{T}})
+                b::TaylorN{S}, a::Taylor1{TaylorN{T}})
             @inbounds aux = $f(b, a.coeffs[1])
             R = eltype(aux)
             coeffs = Array{TaylorN{R}}(a.order+1)

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -8,27 +8,35 @@
 
 ## Auxiliary function ##
 
-function check_taylor1_order!{T<:Number}(coeffs::Array{T,1}, order::Int)
+"""
+    resize_coeffs1!{T<Number}(coeffs::Array{T,1}, order::Int)
+
+If the length of `coeffs` is smaller than `order+1`, it resizes
+`coeffs` appropriately filling it with zeros.
+"""
+function resize_coeffs1!{T<:Number}(coeffs::Array{T,1}, order::Int)
     lencoef = length(coeffs)
-    order = max(order, lencoef-1)
-    order == lencoef-1 && return nothing
+    order ≤ lencoef-1 && return nothing
     resize!(coeffs, order+1)
-    @simd for i = lencoef+1:order+1
-        @inbounds coeffs[i] = zero(coeffs[1])
-    end
-    nothing
+    coeffs[lencoef+1:order+1] .= zero(coeffs[1])
+    return nothing
 end
 
-function check_hpoly_order!{T<:Number}(coeffs::Array{T,1}, order::Int)
+"""
+    resize_coeffsHP!{T<Number}(coeffs::Array{T,1}, order::Int)
+
+If the length of `coeffs` is smaller than the number of coefficients
+correspondinf to `order` (given by `size_table[order+1]`), it resizes
+`coeffs` appropriately filling it with zeros.
+"""
+function resize_coeffsHP!{T<:Number}(coeffs::Array{T,1}, order::Int)
     lencoef = length( coeffs )
     @inbounds num_coeffs = size_table[order+1]
     @assert order ≤ get_order() && lencoef ≤ num_coeffs
     num_coeffs == lencoef && return nothing
     resize!(coeffs, num_coeffs)
-    @simd for i = lencoef+1:num_coeffs
-        @inbounds coeffs[i] = zero(coeffs[1])
-    end
-    nothing
+    coeffs[lencoef+1:num_coeffs] .= zero(coeffs[1])
+    return nothing
 end
 
 ## Minimum order of an HomogeneousPolynomial compatible with the vector's length

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -109,11 +109,11 @@ Base.findfirst{T<:Number}(a::Taylor1{T}) = findfirst(a.coeffs)-1
 ## fixorder ##
 for T in (:Taylor1, :TaylorN)
     @eval begin
-        fixorder{T<:Number}(a::$T{T}, order::Int64) = $T{T}(a.coeffs, order)
+        fixorder(a::$T, order::Int64) = $T(a.coeffs, order)
         function fixorder{R<:Number}(a::$T{R}, b::$T{R})
             a.order == b.order && return a, b
-            a.order < b.order && return $T{R}(a.coeffs, b.order), b
-            return a, $T{R}(b.coeffs, a.order)
+            a.order < b.order && return $T(a.coeffs, b.order), b
+            return a, $T(b.coeffs, a.order)
         end
     end
 end

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -18,7 +18,7 @@ function resize_coeffs1!{T<:Number}(coeffs::Array{T,1}, order::Int)
     lencoef = length(coeffs)
     order ≤ lencoef-1 && return nothing
     resize!(coeffs, order+1)
-    coeffs[lencoef+1:order+1] .= zero(coeffs[1])
+    coeffs[lencoef+1:end] .= zero(coeffs[1])
     return nothing
 end
 
@@ -35,7 +35,7 @@ function resize_coeffsHP!{T<:Number}(coeffs::Array{T,1}, order::Int)
     @assert order ≤ get_order() && lencoef ≤ num_coeffs
     num_coeffs == lencoef && return nothing
     resize!(coeffs, num_coeffs)
-    coeffs[lencoef+1:num_coeffs] .= zero(coeffs[1])
+    coeffs[lencoef+1:end] .= zero(coeffs[1])
     return nothing
 end
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -7,10 +7,7 @@
 #
 
 "Abstract type for Taylor1, HomogeneousPolynomial and TaylorN"
-abstract AbstractSeries{T<:Number} <: Number
-
-"Abbreviation for the union of Real and Complex"
-const RealOrComplex = Union{Real, Complex}
+@compat abstract type AbstractSeries{T<:Number} <: Number end
 
 
 ## Constructors ##
@@ -187,8 +184,9 @@ TaylorN{T<:Number}(::Type{T}, nv::Int; order::Int=get_order()) =
 TaylorN(nv::Int; order::Int=get_order()) = TaylorN(Float64, nv, order=order)
 
 
-# DataType that is a `Number` but not an `AbstractSeries`
+# A `Number` which is not an `AbstractSeries`
 const NumberNotSeries = Union{setdiff(subtypes(Number), [AbstractSeries])...}
-# DataType that is a `Number` but not a TaylorN or HomogeneousPolynomial
+
+# A `Number` which is not a TaylorN nor a HomogeneousPolynomial
 const NumberNotSeriesN =
     Union{setdiff(subtypes(Number), [AbstractSeries])..., Taylor1}

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -9,9 +9,6 @@
 "Abstract type for Taylor1, HomogeneousPolynomial and TaylorN"
 abstract AbstractSeries{T<:Number} <: Number
 
-"Whatever DataType that is a `Number` but not an `AbstractSeries`"
-const NumberNotTaylor = setdiff(subtypes(Number), [AbstractSeries])
-
 "Abbreviation for the union of Real and Complex"
 const RealOrComplex = Union{Real, Complex}
 
@@ -188,3 +185,10 @@ julia> TaylorN(Rational{Int},2)
 TaylorN{T<:Number}(::Type{T}, nv::Int; order::Int=get_order()) =
     return TaylorN( [HomogeneousPolynomial(T, nv)], order )
 TaylorN(nv::Int; order::Int=get_order()) = TaylorN(Float64, nv, order=order)
+
+
+# DataType that is a `Number` but not an `AbstractSeries`
+const NumberNotSeries = Union{setdiff(subtypes(Number), [AbstractSeries])...}
+# DataType that is a `Number` but not a TaylorN or HomogeneousPolynomial
+const NumberNotSeriesN =
+    Union{setdiff(subtypes(Number), [AbstractSeries])..., Taylor1}

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -6,12 +6,21 @@
 # MIT Expat license
 #
 
+"Abstract type for Taylor1, HomogeneousPolynomial and TaylorN"
+abstract AbstractSeries{T<:Number} <: Number
+
+"Whatever DataType that is a `Number` but not an `AbstractSeries`"
+const NumberNotTaylor = setdiff(subtypes(Number), [AbstractSeries])
+
+"Abbreviation for the union of Real and Complex"
+const RealOrComplex = Union{Real, Complex}
+
 
 ## Constructors ##
 
 ######################### Taylor1
 doc"""
-    Taylor1{T<:Number} <: Number
+    Taylor1{T<:Number} <: AbstractSeries{T}
 
 DataType for polynomial expansions in one independent variable.
 
@@ -21,14 +30,14 @@ DataType for polynomial expansions in one independent variable.
     component is the coefficient of degree $i-1$ of the expansion.
 - `order  :: Int64` Maximum order (degree) of the polynomial.
 """
-immutable Taylor1{T<:Number} <: Number
+immutable Taylor1{T<:Number} <: AbstractSeries{T}
     coeffs :: Array{T,1}
     order :: Int
 
     ## Inner constructor ##
     function (::Type{Taylor1{T}}){T}(coeffs::Array{T,1}, order::Int)
-        check_taylor1_order!(coeffs, order)
-        return new{T}(coeffs, order)
+        resize_coeffs1!(coeffs, order)
+        return new{T}(coeffs, length(coeffs)-1)
     end
 end
 
@@ -61,7 +70,7 @@ Taylor1(order::Int=1) = Taylor1(Float64, order)
 
 ######################### HomogeneousPolynomial
 doc"""
-    HomogeneousPolynomial{T<:Number} <: Number
+    HomogeneousPolynomial{T<:Number} <: AbstractSeries{T}
 
 DataType for homogenous polynomials in many (>1) independent variables.
 
@@ -72,12 +81,12 @@ polynomial; the $i$-th component is related to a monomial, where the degrees
 of the independent variables are specified by `coeff_table[order+1][i]`.
 - `order   :: Int` order (degree) of the homogenous polynomial.
 """
-immutable HomogeneousPolynomial{T<:Number} <: Number
+immutable HomogeneousPolynomial{T<:Number} <: AbstractSeries{T}
     coeffs  :: Array{T,1}
     order   :: Int
 
-    function (::Type{HomogeneousPolynomial{T}}){T}( coeffs::Array{T,1}, order::Int )
-        check_hpoly_order!(coeffs, order)
+    function (::Type{HomogeneousPolynomial{T}}){T}(coeffs::Array{T,1}, order::Int)
+        resize_coeffsHP!(coeffs, order)
         return new{T}(coeffs, order)
     end
 end
@@ -120,7 +129,7 @@ HomogeneousPolynomial(nv::Int) = HomogeneousPolynomial(Float64, nv)
 
 ######################### TaylorN
 doc"""
-    TaylorN{T<:Number} <: Number
+    TaylorN{T<:Number} <: AbstractSeries{T}
 
 DataType for polynomial expansions in many (>1) independent variables.
 
@@ -131,11 +140,11 @@ DataType for polynomial expansions in many (>1) independent variables.
 homogeneous polynomial of degree $i-1$.
 - `order   :: Int`  maximum order of the polynomial expansion.
 """
-immutable TaylorN{T<:Number} <: Number
+immutable TaylorN{T<:Number} <: AbstractSeries{T}
     coeffs  :: Array{HomogeneousPolynomial{T},1}
     order   :: Int
 
-    function (::Type{TaylorN{T}}){T}( v::Array{HomogeneousPolynomial{T},1}, order::Int )
+    function (::Type{TaylorN{T}}){T}(v::Array{HomogeneousPolynomial{T},1}, order::Int)
         m = maxorderH(v)
         order = max( m, order )
         coeffs = zeros(HomogeneousPolynomial{T}, order)

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -97,7 +97,7 @@ Evaluate a `HomogeneousPolynomial` polynomial using Horner's rule (hand coded)
 at `vals`.
 """
 # function evaluate{T<:Number}(a::HomogeneousPolynomial{T}, vals::Array{T,1} )
-function evaluate{T<:Number,S<:RealOrComplex}(a::HomogeneousPolynomial{T},
+function evaluate{T<:Number,S<:NumberNotSeriesN}(a::HomogeneousPolynomial{T},
         vals::Array{S,1} )
     @assert length(vals) == get_numvars()
     R = promote_type(T,S)
@@ -121,7 +121,7 @@ end
 Evaluate the `TaylorN` polynomial `a` using Horner's rule (hand coded) at `vals`.
 If `vals` is ommitted, it is evaluated at zero.
 """
-function evaluate{T<:Number,S<:RealOrComplex}(a::TaylorN{T}, vals::Array{S,1} )
+function evaluate{T<:Number,S<:NumberNotSeriesN}(a::TaylorN{T}, vals::Array{S,1} )
     @assert length(vals) == get_numvars()
     numVars = get_numvars()
     R = promote_type(T,S)
@@ -155,7 +155,7 @@ end
 
 ## Evaluates HomogeneousPolynomials and TaylorN on a val of the nv variable
 ## using Horner's rule on the nv variable
-function horner{T<:Number,S<:RealOrComplex}(a::HomogeneousPolynomial{T},
+function horner{T<:Number,S<:NumberNotSeriesN}(a::HomogeneousPolynomial{T},
         b::Tuple{Int,S} )
     nv, val = b
     numVars = get_numvars()
@@ -189,7 +189,7 @@ function horner{T<:Number,S<:RealOrComplex}(a::HomogeneousPolynomial{T},
     return suma
 end
 
-function horner{T<:Number,S<:RealOrComplex}(a::TaylorN{T}, b::Tuple{Int,S} )
+function horner{T<:Number,S<:NumberNotSeriesN}(a::TaylorN{T}, b::Tuple{Int,S} )
 
     nv, val = b
     @assert 1 <= nv <= get_numvars()

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -96,7 +96,6 @@ end
 Evaluate a `HomogeneousPolynomial` polynomial using Horner's rule (hand coded)
 at `vals`.
 """
-# function evaluate{T<:Number}(a::HomogeneousPolynomial{T}, vals::Array{T,1} )
 function evaluate{T<:Number,S<:NumberNotSeriesN}(a::HomogeneousPolynomial{T},
         vals::Array{S,1} )
     @assert length(vals) == get_numvars()

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -96,10 +96,13 @@ end
 Evaluate a `HomogeneousPolynomial` polynomial using Horner's rule (hand coded)
 at `vals`.
 """
-function evaluate{T<:Number}(a::HomogeneousPolynomial{T}, vals::Array{T,1} )
+# function evaluate{T<:Number}(a::HomogeneousPolynomial{T}, vals::Array{T,1} )
+function evaluate{T<:Number,S<:RealOrComplex}(a::HomogeneousPolynomial{T},
+        vals::Array{S,1} )
     @assert length(vals) == get_numvars()
+    R = promote_type(T,S)
     numVars = get_numvars()
-    suma = TaylorN(a, a.order)
+    suma = convert(TaylorN{R}, a)
 
     @inbounds for nv = 1:numVars
         suma = horner(suma, (nv, vals[nv]))
@@ -107,12 +110,7 @@ function evaluate{T<:Number}(a::HomogeneousPolynomial{T}, vals::Array{T,1} )
 
     return suma.coeffs[1].coeffs[1]
 end
-function evaluate{T<:Number,S<:RealOrComplex}(a::HomogeneousPolynomial{T},
-        vals::Array{S,1} )
-    R = promote_type(T,S)
-    return evaluate( convert(HomogeneousPolynomial{R}, a), convert(Array{R,1}, vals))
-end
-function evaluate{T<:Number}(a::HomogeneousPolynomial{T})
+function evaluate(a::HomogeneousPolynomial)
     a.order > 0 && return zero(a.coeffs[1])
     return a.coeffs[1]
 end
@@ -123,10 +121,11 @@ end
 Evaluate the `TaylorN` polynomial `a` using Horner's rule (hand coded) at `vals`.
 If `vals` is ommitted, it is evaluated at zero.
 """
-function evaluate{T<:Number}(a::TaylorN{T}, vals::Array{T,1} )
+function evaluate{T<:Number,S<:RealOrComplex}(a::TaylorN{T}, vals::Array{S,1} )
     @assert length(vals) == get_numvars()
     numVars = get_numvars()
-    suma = a
+    R = promote_type(T,S)
+    suma = convert(TaylorN{R}, a)
 
     @inbounds for nv = 1:numVars
         suma = horner(suma, (nv, vals[nv]))
@@ -134,12 +133,8 @@ function evaluate{T<:Number}(a::TaylorN{T}, vals::Array{T,1} )
 
     return suma.coeffs[1].coeffs[1]
 end
-function evaluate{T<:Number,S<:RealOrComplex}(a::TaylorN{T}, vals::Array{S,1} )
-    R = promote_type(T,S)
-    return evaluate( convert(TaylorN{R}, a), convert(Array{R,1}, vals))
-end
 
-evaluate{T<:Number}(a::TaylorN{T}) = evaluate(a, zeros(T, get_numvars()))
+evaluate{T<:Number}(a::TaylorN{T}) = a.coeffs[1].coeffs[1]
 
 function evaluate!{T<:Number}(x::Array{TaylorN{T},1}, δx::Array{T,1},
         x0::Array{T,1})

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -110,10 +110,7 @@ function evaluate{T<:Number,S<:NumberNotSeriesN}(a::HomogeneousPolynomial{T},
 
     return suma.coeffs[1].coeffs[1]
 end
-function evaluate(a::HomogeneousPolynomial)
-    a.order > 0 && return zero(a.coeffs[1])
-    return a.coeffs[1]
-end
+evaluate(a::HomogeneousPolynomial) = zero(a.coeffs[1])
 
 """
     evaluate(a, [vals])

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -96,40 +96,47 @@ end
 Evaluate a `HomogeneousPolynomial` polynomial using Horner's rule (hand coded)
 at `vals`.
 """
-function evaluate{T<:Number,S<:Union{Real,Complex}}(a::HomogeneousPolynomial{T},
-    vals::Array{S,1} )
-
+function evaluate{T<:Number}(a::HomogeneousPolynomial{T}, vals::Array{T,1} )
+    @assert length(vals) == get_numvars()
     numVars = get_numvars()
-    @assert length(vals) == numVars
-    R = promote_type(T,S)
-    suma = convert(TaylorN{R}, a)
+    suma = TaylorN(a, a.order)
 
-    for nv = 1:numVars
+    @inbounds for nv = 1:numVars
         suma = horner(suma, (nv, vals[nv]))
     end
 
     return suma.coeffs[1].coeffs[1]
 end
+function evaluate{T<:Number,S<:RealOrComplex}(a::HomogeneousPolynomial{T},
+        vals::Array{S,1} )
+    R = promote_type(T,S)
+    return evaluate( convert(HomogeneousPolynomial{R}, a), convert(Array{R,1}, vals))
+end
+function evaluate{T<:Number}(a::HomogeneousPolynomial{T})
+    a.order > 0 && return zero(a.coeffs[1])
+    return a.coeffs[1]
+end
 
 """
     evaluate(a, [vals])
 
-Evaluate a `TaylorN` polynomial using Horner's rule (hand coded) at `vals`.
+Evaluate the `TaylorN` polynomial `a` using Horner's rule (hand coded) at `vals`.
 If `vals` is ommitted, it is evaluated at zero.
 """
-function evaluate{T<:Number,S<:Union{Real,Complex}}(a::TaylorN{T},
-    vals::Array{S,1} )
-
+function evaluate{T<:Number}(a::TaylorN{T}, vals::Array{T,1} )
+    @assert length(vals) == get_numvars()
     numVars = get_numvars()
-    @assert length(vals) == numVars
-    R = promote_type(T,S)
-    suma = convert(TaylorN{R}, a)
+    suma = a
 
-    for nv = 1:numVars
+    @inbounds for nv = 1:numVars
         suma = horner(suma, (nv, vals[nv]))
     end
 
     return suma.coeffs[1].coeffs[1]
+end
+function evaluate{T<:Number,S<:RealOrComplex}(a::TaylorN{T}, vals::Array{S,1} )
+    R = promote_type(T,S)
+    return evaluate( convert(TaylorN{R}, a), convert(Array{R,1}, vals))
 end
 
 evaluate{T<:Number}(a::TaylorN{T}) = evaluate(a, zeros(T, get_numvars()))
@@ -153,9 +160,8 @@ end
 
 ## Evaluates HomogeneousPolynomials and TaylorN on a val of the nv variable
 ## using Horner's rule on the nv variable
-function horner{T<:Number,S<:Union{Real,Complex}}(a::HomogeneousPolynomial{T},
-    b::Tuple{Int,S} )
-
+function horner{T<:Number,S<:RealOrComplex}(a::HomogeneousPolynomial{T},
+        b::Tuple{Int,S} )
     nv, val = b
     numVars = get_numvars()
     @assert 1 <= nv <= numVars
@@ -188,8 +194,7 @@ function horner{T<:Number,S<:Union{Real,Complex}}(a::HomogeneousPolynomial{T},
     return suma
 end
 
-function horner{T<:Number,S<:Union{Real,Complex}}(a::TaylorN{T},
-    b::Tuple{Int,S} )
+function horner{T<:Number,S<:RealOrComplex}(a::TaylorN{T}, b::Tuple{Int,S} )
 
     nv, val = b
     @assert 1 <= nv <= get_numvars()

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -24,12 +24,9 @@ ctranspose{T<:Number}(a::TaylorN{T}) = conj(a)
 
 # Tests `isinf` and `isnan` for *any* of the polynomial coefficients
 for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
-    for f in (:isinf, :isnan)
-        @eval begin
-            function ($f)(a::$T)
-                return any( $f(a.coeffs) )
-            end
-        end
+    @eval begin
+        isinf(a::$T) = any( isinf.(a.coeffs) )
+        isnan(a::$T) = any( isnan.(a.coeffs) )
     end
 end
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -2,8 +2,6 @@
 #
 # Parameters for HomogeneousPolynomial and TaylorN
 
-"Abbreviation for the union of Real and Complex"
-const RealOrComplex = Union{Real, Complex}
 
 @doc """
     ParamsTaylorN

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -65,7 +65,10 @@ using Base.Test
     @test promote(xT, [xH,yH])[2] == xT+yT
     @test typeof(promote(im*xT,[xH,yH])[2]) == TaylorN{Complex{Int64}}
     @test TaylorSeries.fixorder(TaylorN(1, order=1),17) == xT
-    @test TaylorSeries.iszero(zeroT.coeffs[2])
+    @test iszero(zeroT.coeffs)
+    @test iszero(zero(xH))
+    @test !iszero(uT)
+    @test iszero(zeroT)
 
     @test HomogeneousPolynomial(xH,1) == HomogeneousPolynomial(xH)
     @test eltype(xH) == Int

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -5,6 +5,10 @@ using TaylorSeries
 using Base.Test
 
 @testset "Tests for HomogeneousPolynomial and TaylorN" begin
+    @test HomogeneousPolynomial <: AbstractSeries
+    @test HomogeneousPolynomial{Int} <: AbstractSeries{Int}
+    @test TaylorN{Float64} <: AbstractSeries{Float64}
+
     @test eltype(set_variables(Int, "x", numvars=2, order=6))  == TaylorN{Int}
     @test eltype(set_variables("x", numvars=2, order=6))  == TaylorN{Float64}
     @test eltype(set_variables(BigInt, "x y", order=6))  == TaylorN{BigInt}

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -28,9 +28,13 @@ using Base.Test
     @test y == HomogeneousPolynomial(Float64, 2)
     @test y == HomogeneousPolynomial(2)
     @test !isnan(x)
-    set_variables("x", numvars=2, order=17)
 
     set_variables("x", numvars=2, order=17)
+    v = [1,2]
+    @test typeof(TaylorSeries.resize_coeffsHP!(v,2)) == Void
+    @test v == [1,2,0]
+    @test_throws AssertionError TaylorSeries.resize_coeffsHP!(v,1)
+
     xH = HomogeneousPolynomial([1,0])
     yH = HomogeneousPolynomial([0,1],1)
     @test HomogeneousPolynomial(0,0)  == 0
@@ -41,9 +45,12 @@ using Base.Test
     @test zeroT.coeffs[1] == HomogeneousPolynomial(0, 0)
     @test uT.coeffs[1] == HomogeneousPolynomial(1, 0)
     @test ones(xH,1) == [1, xH+yH]
+    @test typeof(ones(xH,2)) == Array{HomogeneousPolynomial{Int},1}
     @test ones(HomogeneousPolynomial{Complex{Int}},0) ==
         [HomogeneousPolynomial([complex(1,0)], 0)]
     @test !isnan(uT)
+    @test TaylorSeries.fixorder(xH,yH) == (xH,yH)
+    @test_throws AssertionError TaylorSeries.fixorder(zeros(xH,0)[1],yH)
 
     @test get_order(zeroT) == 1
     @test get_coeff(xT,[1,0]) == 1
@@ -110,6 +117,7 @@ using Base.Test
     @test xT/complex(0,BigInt(3)) == -im*xT/BigInt(3)
     @test (xH/complex(0,BigInt(3)))' ==
         im*HomogeneousPolynomial([BigInt(1),0])/3
+    @test evaluate(xH) == zero(eltype(xH))
 
     @test derivative(2xT*yT^2,1) == 2yT^2
     @test xT*xT^3 == xT^4

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -30,6 +30,7 @@ using Base.Test
     @test !isnan(x)
     set_variables("x", numvars=2, order=17)
 
+    set_variables("x", numvars=2, order=17)
     xH = HomogeneousPolynomial([1,0])
     yH = HomogeneousPolynomial([0,1],1)
     @test HomogeneousPolynomial(0,0)  == 0

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -5,6 +5,9 @@ using TaylorSeries
 using Base.Test
 
 @testset "Tests with mixures of Taylor1 and TaylorN" begin
+    @test TaylorSeries.NumberNotSeries == Union{Real,Complex}
+    @test TaylorSeries.NumberNotSeriesN == Union{Real,Complex,Taylor1}
+
     set_variables("x", numvars=2, order=6)
     xH = HomogeneousPolynomial(Int, 1)
     yH = HomogeneousPolynomial(Int, 2)
@@ -96,6 +99,7 @@ using Base.Test
     @test one(y)/(1+x) == 1 - x + x^2 - x^3 + x^4 - x^5
     @test one(y)/(1+y) == 1 - y + y^2 - y^3 + y^4 - y^5
     @test (1+y)/one(t) == 1 + y
+    @test typeof(y+t) == TaylorN{Taylor1{Float64}}
 
     # See #92 and #94
     δx, δy = set_variables("δx δy")
@@ -115,4 +119,5 @@ using Base.Test
     @test xx/xx == one(xx)
     @test xx*δx + Taylor1(typeof(δx),5) == δx + δx^2 + Taylor1(typeof(δx),5)
     @test xx/(1+δx) == one(xx)
+    @test typeof(xx+δx) == Taylor1{TaylorN{Float64}}
 end

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -89,18 +89,26 @@ using Base.Test
     t = Taylor1(10)
     x = TaylorN( [HomogeneousPolynomial(zero(t)), HomogeneousPolynomial([one(t),zero(t)])], 5)
     y = TaylorN(typeof(tint), 2, order=5)
+    @test typeof(x) == TaylorN{Taylor1{Float64}}
+    @test eltype(y) == Taylor1{Int}
+    @test -x == 0 - x
+    @test +y == y
     @test one(y)/(1+x) == 1 - x + x^2 - x^3 + x^4 - x^5
     @test one(y)/(1+y) == 1 - y + y^2 - y^3 + y^4 - y^5
 
     # See #92 and #94
     δx, δy = set_variables("δx δy")
     xx = 1+Taylor1(δx,5)
+    @test typeof(xx) == Taylor1{TaylorN{Float64}}
+    @test eltype(xx) == TaylorN{Float64}
     @test !isnan(xx)
     @test !isnan(δx)
     @test !isinf(xx)
     @test !isinf(δx)
-    @test xx/1.0 == xx
-    @test xx + xx == 2xx
+    @test +xx == xx
+    @test -xx == 0 - xx
+    @test xx/1.0 == 1.0*xx
+    @test xx + xx == xx*2
     @test xx - xx == zero(xx)
     @test xx*xx == xx^2
     @test xx/xx == one(xx)

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -92,11 +92,17 @@ using Base.Test
     @test one(y)/(1+x) == 1 - x + x^2 - x^3 + x^4 - x^5
     @test one(y)/(1+y) == 1 - y + y^2 - y^3 + y^4 - y^5
 
-    # See
-    xx = 1.0 + TaylorN(Float64, 1, order=5)
-    tx = Taylor1(xx, 16)
-    @test !isnan(tx)
-    @test !isinf(tx)
-    @test tx/tx == one(tx)
-    @test tx/1.0 == tx
+    # See #92 and #94
+    δx, δy = set_variables("δx δy")
+    xx = 1+Taylor1(δx,5)
+    @test !isnan(xx)
+    @test !isnan(δx)
+    @test !isinf(xx)
+    @test !isinf(δx)
+    @test xx/1.0 == xx
+    @test xx + xx == 2xx
+    @test xx - xx == zero(xx)
+    @test xx*xx == xx^2
+    @test xx/xx == one(xx)
+    @test xx/(1+δx) == one(xx)
 end

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -95,6 +95,7 @@ using Base.Test
     @test +y == y
     @test one(y)/(1+x) == 1 - x + x^2 - x^3 + x^4 - x^5
     @test one(y)/(1+y) == 1 - y + y^2 - y^3 + y^4 - y^5
+    @test (1+y)/one(t) == 1 + y
 
     # See #92 and #94
     δx, δy = set_variables("δx δy")
@@ -112,5 +113,6 @@ using Base.Test
     @test xx - xx == zero(xx)
     @test xx*xx == xx^2
     @test xx/xx == one(xx)
+    @test xx*δx + Taylor1(typeof(δx),5) == δx + δx^2 + Taylor1(typeof(δx),5)
     @test xx/(1+δx) == one(xx)
 end

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -12,6 +12,9 @@ using Base.Test
     ot = 1.0*one(t)
     tol1 = eps(1.0)
 
+    @test Taylor1 <: AbstractSeries
+    @test Taylor1{Float64} <: AbstractSeries{Float64}
+
     v = [1,2]
     @test typeof(TaylorSeries.resize_coeffs1!(v,3)) == Void
     @test v == [1,2,0,0]
@@ -64,6 +67,8 @@ using Base.Test
     @test 0*t == zt
     @test (-t)^2 == tsquare
     @test t^3 == tsquare*t
+    @test zero(t)/t == zero(t)
+    @test one(t)/one(t) == 1.0
     @test tsquare/t == t
     @test t/(t*3) == (1/3)*ot
     @test t/3im == -tim/3

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -34,6 +34,8 @@ using Base.Test
     @test eltype(TaylorSeries.fixorder(zt,Taylor1([1]))[1]) == Int
     @test TaylorSeries.findfirst(t) == 1
     @test TaylorSeries.findfirst(zt) == -1
+    @test iszero(zero(t))
+    @test !iszero(one(t))
     @test isinf(Taylor1([typemax(1.0)]))
     @test isnan(Taylor1([typemax(1.0), NaN]))
 

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -12,6 +12,12 @@ using Base.Test
     ot = 1.0*one(t)
     tol1 = eps(1.0)
 
+    v = [1,2]
+    @test typeof(TaylorSeries.resize_coeffs1!(v,3)) == Void
+    @test v == [1,2,0,0]
+    TaylorSeries.resize_coeffs1!(v,0)
+    @test v == [1,2,0,0]
+
     @test Taylor1([0,1,0,0]) == Taylor1(3)
     @test get_coeff(Taylor1(Complex128,3),1) == complex(1.0,0.0)
     @inferred convert(Taylor1{Complex128},ot) == Taylor1{Complex128}
@@ -128,7 +134,10 @@ using Base.Test
     @test sinh(t) == imag(sin(im*t))
 
     v = [sin(t), exp(-t)]
-    @test evaluate(v) == [0.0, 1.0]
+    vv = Vector{Float64}(2)
+    @test evaluate!(v, zero(Int), vv) == nothing
+    @test vv == [0.0,1.0]
+    @test evaluate(v) == vv
     @test evaluate(v, complex(0.0,0.2)) ==
         [complex(0.0,sinh(0.2)),complex(cos(0.2),sin(-0.2))]
     @test derivative(5, exp(ta(1.0))) == exp(1.0)


### PR DESCRIPTION
This PR began as an attempt to get rid of the use `fixorder`, which creates copies of Taylor1 objects. This has been accomplished to a certain extent using dot-operatotions and dot-functions. But I couldn't get rid of some cases. 

While working on this, #92 appeared followed by #94. I think I have solved this now by introducing new methods, and restricting more carefully some methods according to their methods. 
