### PR TITLE
Add `getindex`, `setindex!` methods for `::Colon`

### DIFF
--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -76,8 +76,10 @@ function getindex(a::Taylor1, n::Int)
     return zero(a.coeffs[1])
 end
 getindex(a::Taylor1, n::UnitRange) = a.coeffs[n]
+getindex(a::Taylor1, c::Colon) = a.coeffs[c]
 setindex!{T<:Number}(a::Taylor1{T}, x::T, n::Int) = a.coeffs[n] = x
 setindex!{T<:Number}(a::Taylor1{T}, x::T, n::UnitRange) = a.coeffs[n] = x
+setindex!{T<:Number}(a::Taylor1{T}, x::T, c::Colon) = a.coeffs[c] = x
 
 
 
@@ -96,10 +98,13 @@ end
 
 getindex(a::HomogeneousPolynomial, n::Int) = a.coeffs[n]
 getindex(a::HomogeneousPolynomial, n::UnitRange) = a.coeffs[n]
+getindex(a::HomogeneousPolynomial, c::Colon) = a.coeffs[c]
 setindex!{T<:Number}(a::HomogeneousPolynomial{T}, x::T, n::Int) =
     a.coeffs[n] = x
 setindex!{T<:Number}(a::HomogeneousPolynomial{T}, x::T, n::UnitRange) =
     a.coeffs[n] = x
+setindex!{T<:Number}(a::HomogeneousPolynomial{T}, x::T, c::Colon) =
+    a.coeffs[c] = x
 
 
 """
@@ -120,6 +125,7 @@ function getindex(a::TaylorN, n::Int)
     throw(BoundsError(a.coeffs,n))
 end
 getindex(a::TaylorN, n::UnitRange) = a.coeffs[n]
+getindex(a::TaylorN, c::Colon) = a.coeffs[c]
 setindex!{T<:Number}(a::TaylorN{T}, x::HomogeneousPolynomial{T}, n::Int) =
     a.coeffs[n] = x
 setindex!{T<:Number}(a::TaylorN{T}, x::T, n::Int) =
@@ -128,6 +134,10 @@ setindex!{T<:Number}(a::TaylorN{T}, x::HomogeneousPolynomial{T}, n::UnitRange) =
     a.coeffs[n] = x
 setindex!{T<:Number}(a::TaylorN{T}, x::T, n::UnitRange) =
     a.coeffs[n] = x
+setindex!{T<:Number}(a::TaylorN{T}, x::HomogeneousPolynomial{T}, c::Colon) =
+    a.coeffs[c] = x
+setindex!{T<:Number}(a::TaylorN{T}, x::T, c::Colon) =
+    a.coeffs[c] = x
 
 
 ## eltype, length, endof, get_order ##

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -79,8 +79,9 @@ getindex(a::Taylor1, n::UnitRange) = a.coeffs[n]
 getindex(a::Taylor1, c::Colon) = a.coeffs[c]
 setindex!{T<:Number}(a::Taylor1{T}, x::T, n::Int) = a.coeffs[n] = x
 setindex!{T<:Number}(a::Taylor1{T}, x::T, n::UnitRange) = a.coeffs[n] = x
+setindex!{T<:Number}(a::Taylor1{T}, x::Array{T,1}, n::UnitRange) = a.coeffs[n] = x
 setindex!{T<:Number}(a::Taylor1{T}, x::T, c::Colon) = a.coeffs[c] = x
-
+setindex!{T<:Number}(a::Taylor1{T}, x::Array{T,1}, c::Colon) = a.coeffs[c] = x
 
 
 """
@@ -103,7 +104,11 @@ setindex!{T<:Number}(a::HomogeneousPolynomial{T}, x::T, n::Int) =
     a.coeffs[n] = x
 setindex!{T<:Number}(a::HomogeneousPolynomial{T}, x::T, n::UnitRange) =
     a.coeffs[n] = x
+setindex!{T<:Number}(a::HomogeneousPolynomial{T}, x::Array{T,1}, n::UnitRange) =
+    a.coeffs[n] = x
 setindex!{T<:Number}(a::HomogeneousPolynomial{T}, x::T, c::Colon) =
+    a.coeffs[c] = x
+setindex!{T<:Number}(a::HomogeneousPolynomial{T}, x::Array{T,1}, c::Colon) =
     a.coeffs[c] = x
 
 
@@ -134,9 +139,17 @@ setindex!{T<:Number}(a::TaylorN{T}, x::HomogeneousPolynomial{T}, n::UnitRange) =
     a.coeffs[n] = x
 setindex!{T<:Number}(a::TaylorN{T}, x::T, n::UnitRange) =
     a.coeffs[n] = x
+setindex!{T<:Number}(a::TaylorN{T}, x::Array{HomogeneousPolynomial{T},1}, n::UnitRange) =
+    a.coeffs[n] = x
+setindex!{T<:Number}(a::TaylorN{T}, x::Array{T,1}, n::UnitRange) =
+    a.coeffs[n] = x
 setindex!{T<:Number}(a::TaylorN{T}, x::HomogeneousPolynomial{T}, c::Colon) =
     a.coeffs[c] = x
 setindex!{T<:Number}(a::TaylorN{T}, x::T, c::Colon) =
+    a.coeffs[c] = x
+setindex!{T<:Number}(a::TaylorN{T}, x::Array{HomogeneousPolynomial{T},1}, c::Colon) =
+    a.coeffs[c] = x
+setindex!{T<:Number}(a::TaylorN{T}, x::Array{T,1}, c::Colon) =
     a.coeffs[c] = x
 
 

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -75,8 +75,8 @@ function getindex(a::Taylor1, n::Int)
     (1 ≤ n ≤ length(a.coeffs)) && return a.coeffs[n]
     return zero(a.coeffs[1])
 end
-getindex(a::Taylor1, n::UnitRange) = a.coeffs[n]
-getindex(a::Taylor1, c::Colon) = a.coeffs[c]
+getindex(a::Taylor1, n::UnitRange) = view(a.coeffs, n)
+getindex(a::Taylor1, c::Colon) = view(a.coeffs, c)
 setindex!{T<:Number}(a::Taylor1{T}, x::T, n::Int) = a.coeffs[n] = x
 setindex!{T<:Number}(a::Taylor1{T}, x::T, n::UnitRange) = a.coeffs[n] = x
 setindex!{T<:Number}(a::Taylor1{T}, x::Array{T,1}, n::UnitRange) = a.coeffs[n] = x
@@ -98,8 +98,8 @@ function get_coeff(a::HomogeneousPolynomial, v::Array{Int,1})
 end
 
 getindex(a::HomogeneousPolynomial, n::Int) = a.coeffs[n]
-getindex(a::HomogeneousPolynomial, n::UnitRange) = a.coeffs[n]
-getindex(a::HomogeneousPolynomial, c::Colon) = a.coeffs[c]
+getindex(a::HomogeneousPolynomial, n::UnitRange) = view(a.coeffs, n)
+getindex(a::HomogeneousPolynomial, c::Colon) = view(a.coeffs, c)
 setindex!{T<:Number}(a::HomogeneousPolynomial{T}, x::T, n::Int) =
     a.coeffs[n] = x
 setindex!{T<:Number}(a::HomogeneousPolynomial{T}, x::T, n::UnitRange) =
@@ -129,8 +129,8 @@ function getindex(a::TaylorN, n::Int)
     n ≤ get_order()+1 && return zero_korder(a, n-1)
     throw(BoundsError(a.coeffs,n))
 end
-getindex(a::TaylorN, n::UnitRange) = a.coeffs[n]
-getindex(a::TaylorN, c::Colon) = a.coeffs[c]
+getindex(a::TaylorN, n::UnitRange) = view(a.coeffs, n)
+getindex(a::TaylorN, c::Colon) = view(a.coeffs, c)
 setindex!{T<:Number}(a::TaylorN{T}, x::HomogeneousPolynomial{T}, n::Int) =
     a.coeffs[n] = x
 setindex!{T<:Number}(a::TaylorN{T}, x::T, n::Int) =

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -155,6 +155,20 @@ using Base.Test
     rv = a[end][1:end] .= rand.()
     @test a[end][1:end] == rv
     @test a[end][1:end] != b[end][1:end]
+    hp = HomogeneousPolynomial(1)^8
+    rv1 = rand( length(hp) )
+    hp[:] = rv1
+    @test rv1 == hp[:]
+    rv2 = rand( length(hp)-2 )
+    hp[1:end-2] = rv2
+    @test hp[1:end-2] == rv2
+    @test hp[end-1:end] == rv1[end-1:end]
+    hp[3:4] = 0.0
+    @test hp[1:2] == rv2[1:2]
+    @test hp[3:4] == [0.0, 0.0]
+    @test hp[5:end-2] == rv2[5:end]
+    @test hp[end-1:end] == rv1[end-1:end]
+
 
     @test_throws DomainError yT^(-2)
     @test_throws DomainError yT^(-2.0)

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -165,9 +165,11 @@ using Base.Test
     @test hp[end-1:end] == rv1[end-1:end]
     hp[3:4] = 0.0
     @test hp[1:2] == rv2[1:2]
-    @test hp[3:4] == [0.0, 0.0]
+    @test hp[3:4] == zeros(2)
     @test hp[5:end-2] == rv2[5:end]
     @test hp[end-1:end] == rv1[end-1:end]
+    hp[:] = 0.0
+    @test hp[:] == zero(rv1)
 
 
     @test_throws DomainError yT^(-2)

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -138,25 +138,23 @@ using Base.Test
     @test ( (1+TaylorN(1))^TaylorN(2) )[:] == ( (1+TaylorN(1))^TaylorN(2) ).coeffs[:]
     @test txy.coeffs[:] == txy[:]
     @test txy.coeffs[:] == txy[1:end]
-    txy[:] = ( -1.0 + 3xT*yT - xT^2*yT + (4/3)*xT^3*yT + (1/3)*xT*yT^3 + 0.5*xT^2*yT^2 + 0.5*xT*yT^3 )[:]
+    txy[:] .= ( -1.0 + 3xT*yT - xT^2*yT + (4/3)*xT^3*yT + (1/3)*xT*yT^3 + 0.5*xT^2*yT^2 + 0.5*xT*yT^3 )[:]
     @test txy[:] == ( -1.0 + 3xT*yT - xT^2*yT + (4/3)*xT^3*yT + (1/3)*xT*yT^3 + 0.5*xT^2*yT^2 + 0.5*xT*yT^3 )[:]
-    txy[2:end-1] = ( 1.0 - xT*yT + 0.5*xT^2*yT - (2/3)*xT*yT^3 - 0.5*xT^2*yT^2  + 7*xT^3*yT )[2:end-1]
+    txy[2:end-1] .= ( 1.0 - xT*yT + 0.5*xT^2*yT - (2/3)*xT*yT^3 - 0.5*xT^2*yT^2  + 7*xT^3*yT )[2:end-1]
     @test txy[2:end-1] == ( 1.0 - xT*yT + 0.5*xT^2*yT - (2/3)*xT*yT^3 - 0.5*xT^2*yT^2  + 7*xT^3*yT )[2:end-1]
-    aTN = -5.0 + sin(xT+yT^2)
-    bTN = deepcopy(aTN)
-    @test aTN[:] == aTN[1:end]
-    @test aTN[:] == bTN[:]
-    @test aTN[1:end] == bTN[1:end]
-    @test aTN[end][:] == bTN[end][:]
-    @test aTN[end][1:end] == bTN[end][1:end]
-    rv = rand(18)
-    aTN[end][:] = rv
-    @test aTN[end][:] == rv
-    @test aTN[end][:] != bTN[end][:]
-    rv = rand(18)
-    aTN[end][1:end] = rv
-    @test aTN[end][1:end] == rv
-    @test aTN[end][1:end] != bTN[end][1:end]
+    a = -5.0 + sin(xT+yT^2)
+    b = deepcopy(a)
+    @test a[:] == a[1:end]
+    @test a[:] == b[:]
+    @test a[1:end] == b[1:end]
+    @test a[end][:] == b[end][:]
+    @test a[end][1:end] == b[end][1:end]
+    rv = a[end][:] .= rand.()
+    @test a[end][:] == rv
+    @test a[end][:] != b[end][:]
+    rv = a[end][1:end] .= rand.()
+    @test a[end][1:end] == rv
+    @test a[end][1:end] != b[end][1:end]
 
     @test_throws DomainError yT^(-2)
     @test_throws DomainError yT^(-2.0)

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -185,19 +185,33 @@ using Base.Test
     @test q[1] == pol[1]
     @test q[end] == pol[end]
     q[:] = pol.coeffs
-    @test q == pol
-    @test q[:] == pol[:]
     zH0 = zero(HomogeneousPolynomial{Float64})
     q[:] = zH0
     @test q[:] == zero(q[:])
     q[:] = pol.coeffs
-    @test q == pol
-    @test q[:] == pol[:]
     q[2:end-1] = zH0
     @test q[2:end-1] == zero(q[2:end-1])
     @test q[1] == pol[1]
     @test q[end] == pol[end]
-
+    q[:] = pol.coeffs
+    zHall = zeros(HomogeneousPolynomial{Float64}, q.order)
+    q[:] = zHall
+    @test q[:] == zHall
+    q[:] = pol.coeffs
+    q[2:end-1] = zHall[2:end-1]
+    @test q[2:end-1] == zHall[2:end-1]
+    q[:] = pol.coeffs
+    @test q[:] != zeros(q.order+1)
+    q[:] = zeros(q.order+1)
+    @test q[:] == zeros(q.order+1)
+    q[:] = pol.coeffs
+    q[2:end-1] = zeros(q.order+1)[2:end-1]
+    @test q != pol
+    @test q[:] != pol[:]
+    @test q[2:end-1] == zeros(q.order+1)[2:end-1]
+    @test q[1] == pol[1]
+    @test q[end] == pol[end]
+    
 
     @test_throws DomainError yT^(-2)
     @test_throws DomainError yT^(-2.0)

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -135,6 +135,29 @@ using Base.Test
     @test xT*xT^3 == xT^4
     txy = 1.0 + xT*yT - 0.5*xT^2*yT + (1/3)*xT^3*yT + 0.5*xT^2*yT^2
     @test getindex((1+TaylorN(1))^TaylorN(2),1:5) == txy.coeffs[1:5]
+    @test ( (1+TaylorN(1))^TaylorN(2) )[:] == ( (1+TaylorN(1))^TaylorN(2) ).coeffs[:]
+    @test txy.coeffs[:] == txy[:]
+    @test txy.coeffs[:] == txy[1:end]
+    txy[:] = ( -1.0 + 3xT*yT - xT^2*yT + (4/3)*xT^3*yT + (1/3)*xT*yT^3 + 0.5*xT^2*yT^2 + 0.5*xT*yT^3 )[:]
+    @test txy[:] == ( -1.0 + 3xT*yT - xT^2*yT + (4/3)*xT^3*yT + (1/3)*xT*yT^3 + 0.5*xT^2*yT^2 + 0.5*xT*yT^3 )[:]
+    txy[2:end-1] = ( 1.0 - xT*yT + 0.5*xT^2*yT - (2/3)*xT*yT^3 - 0.5*xT^2*yT^2  + 7*xT^3*yT )[2:end-1]
+    @test txy[2:end-1] == ( 1.0 - xT*yT + 0.5*xT^2*yT - (2/3)*xT*yT^3 - 0.5*xT^2*yT^2  + 7*xT^3*yT )[2:end-1]
+    aTN = -5.0 + sin(xT+yT^2)
+    bTN = deepcopy(aTN)
+    @test aTN[:] == aTN[1:end]
+    @test aTN[:] == bTN[:]
+    @test aTN[1:end] == bTN[1:end]
+    @test aTN[end][:] == bTN[end][:]
+    @test aTN[end][1:end] == bTN[end][1:end]
+    rv = rand(18)
+    aTN[end][:] = rv
+    @test aTN[end][:] == rv
+    @test aTN[end][:] != bTN[end][:]
+    rv = rand(18)
+    aTN[end][1:end] = rv
+    @test aTN[end][1:end] == rv
+    @test aTN[end][1:end] != bTN[end][1:end]
+
     @test_throws DomainError yT^(-2)
     @test_throws DomainError yT^(-2.0)
     @test (1+xT)^(3//2) == ((1+xT)^0.5)^3

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -142,6 +142,7 @@ using Base.Test
     @test txy[:] == ( -1.0 + 3xT*yT - xT^2*yT + (4/3)*xT^3*yT + (1/3)*xT*yT^3 + 0.5*xT^2*yT^2 + 0.5*xT*yT^3 )[:]
     txy[2:end-1] .= ( 1.0 - xT*yT + 0.5*xT^2*yT - (2/3)*xT*yT^3 - 0.5*xT^2*yT^2  + 7*xT^3*yT )[2:end-1]
     @test txy[2:end-1] == ( 1.0 - xT*yT + 0.5*xT^2*yT - (2/3)*xT*yT^3 - 0.5*xT^2*yT^2  + 7*xT^3*yT )[2:end-1]
+
     a = -5.0 + sin(xT+yT^2)
     b = deepcopy(a)
     @test a[:] == a[1:end]
@@ -155,6 +156,7 @@ using Base.Test
     rv = a[end][1:end] .= rand.()
     @test a[end][1:end] == rv
     @test a[end][1:end] != b[end][1:end]
+
     hp = HomogeneousPolynomial(1)^8
     rv1 = rand( length(hp) )
     hp[:] = rv1
@@ -170,6 +172,31 @@ using Base.Test
     @test hp[end-1:end] == rv1[end-1:end]
     hp[:] = 0.0
     @test hp[:] == zero(rv1)
+
+    pol = sin(xT+yT*xT)+yT^2-(1-xT)^3
+    q = deepcopy(pol)
+    q[:] = 0.0
+    @test q[:] == zero(q[:])
+    q[:] = pol.coeffs
+    @test q == pol
+    @test q[:] == pol[:]
+    q[2:end-1] = 0.0
+    @test q[2:end-1] == zero(q[2:end-1])
+    @test q[1] == pol[1]
+    @test q[end] == pol[end]
+    q[:] = pol.coeffs
+    @test q == pol
+    @test q[:] == pol[:]
+    zH0 = zero(HomogeneousPolynomial{Float64})
+    q[:] = zH0
+    @test q[:] == zero(q[:])
+    q[:] = pol.coeffs
+    @test q == pol
+    @test q[:] == pol[:]
+    q[2:end-1] = zH0
+    @test q[2:end-1] == zero(q[2:end-1])
+    @test q[1] == pol[1]
+    @test q[end] == pol[end]
 
 
     @test_throws DomainError yT^(-2)

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -211,7 +211,13 @@ using Base.Test
     @test q[2:end-1] == zeros(q.order+1)[2:end-1]
     @test q[1] == pol[1]
     @test q[end] == pol[end]
-    
+    q[:] = pol.coeffs
+    pol2 = cos(sin(xT)-yT^3*xT)-3yT^2+sqrt(1-xT)
+    q[3:end-2] = pol2.coeffs[3:end-2]
+    @test q[1:2] == pol[1:2]
+    @test q[3:end-2] == pol2[3:end-2]
+    @test q[end-1:end] == pol[end-1:end]
+
 
     @test_throws DomainError yT^(-2)
     @test_throws DomainError yT^(-2.0)

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -4,7 +4,7 @@
 using TaylorSeries
 using Base.Test
 
-@testset "Tests with mixures of Taylor1 and TaylorN" begin
+@testset "Tests with mixtures of Taylor1 and TaylorN" begin
     @test TaylorSeries.NumberNotSeries == Union{Real,Complex}
     @test TaylorSeries.NumberNotSeriesN == Union{Real,Complex,Taylor1}
 

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -42,6 +42,12 @@ using Base.Test
     y[1:5] = rv
     @test y[1:5] == rv
     @test y[6:end] == sin(Taylor1(16))[6:end]
+    rv = rand( length(y.coeffs) )
+    y[:] = rv
+    @test y[:] == rv
+    y[:] = cos(Taylor1(16)).coeffs
+    @test y == cos(Taylor1(16))
+    @test y[:] == cos(Taylor1(16))[:]
     y[:] = 0.0
     @test y[:] == zero(y[:])
     y = sin(Taylor1(16))

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -34,7 +34,8 @@ using Base.Test
     @test Taylor1(rv)[:] == Taylor1(rv)[1:end]
     y = sin(Taylor1(16))
     @test y[:] == sin(Taylor1(16))[:]
-    y[:] = cos(Taylor1(16))[:]
+    y[:] .= cos(Taylor1(16))[:]
+    @test y == cos(Taylor1(16))
     @test y[:] == cos(Taylor1(16))[:]
     y = sin(Taylor1(16))
     rv = rand(5)
@@ -43,6 +44,12 @@ using Base.Test
     @test y[6:end] == sin(Taylor1(16))[6:end]
     y[:] = 0.0
     @test y[:] == zero(y[:])
+    y = sin(Taylor1(16))
+    rv = y[1:5] .= rand.()
+    @test y[1:5] == rv
+    @test y[6:end] == sin(Taylor1(16))[6:end]
+    rv = y[:] .= rand.()
+    @test y[:] == rv
 
     @test Taylor1([0,1,0,0]) == Taylor1(3)
     @test get_coeff(Taylor1(Complex128,3),1) == complex(1.0,0.0)

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -24,6 +24,10 @@ using Base.Test
     @test v == [1,2,3,0]
     setindex!(Taylor1(v),0,1:3)
     @test v == zero(v)
+    setindex!(Taylor1(v),1,:)
+    @test v == [1,1,1,1]
+    Taylor1(v)[:] = 0
+    @test v == zero(v)
 
     @test Taylor1([0,1,0,0]) == Taylor1(3)
     @test get_coeff(Taylor1(Complex128,3),1) == complex(1.0,0.0)

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -22,12 +22,27 @@ using Base.Test
     @test v == [1,2,0,0]
     setindex!(Taylor1(v),3,3)
     @test v == [1,2,3,0]
+    @test Taylor1(v)[:] == [1,2,3,0]
+    @test Taylor1(v)[:] == Taylor1(v).coeffs[:]
     setindex!(Taylor1(v),0,1:3)
     @test v == zero(v)
     setindex!(Taylor1(v),1,:)
     @test v == [1,1,1,1]
     Taylor1(v)[:] = 0
     @test v == zero(v)
+    rv = [rand(0:3) for i in 1:4]
+    @test Taylor1(rv)[:] == Taylor1(rv)[1:end]
+    y = sin(Taylor1(16))
+    @test y[:] == sin(Taylor1(16))[:]
+    y[:] = cos(Taylor1(16))[:]
+    @test y[:] == cos(Taylor1(16))[:]
+    y = sin(Taylor1(16))
+    rv = rand(5)
+    y[1:5] = rv
+    @test y[1:5] == rv
+    @test y[6:end] == sin(Taylor1(16))[6:end]
+    y[:] = 0.0
+    @test y[:] == zero(y[:])
 
     @test Taylor1([0,1,0,0]) == Taylor1(3)
     @test get_coeff(Taylor1(Complex128,3),1) == complex(1.0,0.0)


### PR DESCRIPTION
This PR is aimed at solving the issue mentioned in #100. It adds `getindex` and `setindex!` methods for `::Colon`, along with corresponding tests. It also adds a new `setindex!` method for `Taylor1`, which allows the user to do:

```julia
julia> using TaylorSeries

julia> y = sin(Taylor1(16))
 1.0 t - 0.16666666666666666 t³ + 0.008333333333333333 t⁵ - 0.0001984126984126984 t⁷ + 2.7557319223985893e-6 t⁹ - 2.505210838544172e-8 t¹¹ + 1.6059043836821616e-10 t¹³ - 7.647163731819817e-13 t¹⁵ + 𝒪(t¹⁷)

julia> y[1:5] = rand(5)
5-element Array{Float64,1}:
 0.996061
 0.430487
 0.776109
 0.207677
 0.353624

julia> y
 0.9960609386261976 + 0.43048731930377904 t + 0.7761091106019427 t² + 0.20767709964338787 t³ + 0.3536237457090481 t⁴ + 0.008333333333333333 t⁵ - 0.0001984126984126984 t⁷ + 2.7557319223985893e-6 t⁹ - 2.505210838544172e-8 t¹¹ + 1.6059043836821616e-10 t¹³ - 7.647163731819817e-13 t¹⁵ + 𝒪(t¹⁷)

julia> y == sin(Taylor1(16))
false
```

Similar new methods for `setindex!` have been added for `TaylorN` and `HomogeneousPolynomial`. Tests are passing in travis. Feedback is welcome!