### PR TITLE
Changed evaluate method for TaylorN and HomogeneousPolynomial.

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -166,7 +166,41 @@ function evaluate{T<:Number,S<:NumberNotSeriesN}(a::TaylorSeries.TaylorN{T},
         suma[homPol] = sun
     end
 
-    #here it only works with <:Real numbers...
-    return sum(sort(suma))
+    return sort_n_sum(suma)
 end
 evaluate{T<:Number}(a::TaylorN{T}) = a[1][1]
+
+## auxiliary function for a precise evaluation of evaluate
+"""
+    sort_n_sum(a)
+
+Auxiliary function for an accurate evaluation of `evaluate`.
+"""
+function sort_n_sum{T<:NumberNotSeriesN}(a::Array{T,1})
+
+    if T <: Real
+        suma = sum(sort(a,by=abs))
+
+    elseif T <: Complex
+        suma = sum(sort(real(a),by=abs) + sort(imag(a),by=abs)*im)
+
+    elseif T <: Taylor1
+        ord = a[1].order+1
+        T_type = eltype(a[1])
+        a_length = length(a)
+
+        tmp1 = Array(T_type,ord)
+        tmp2 = Array(T_type,a_length)
+
+        for o in 1:ord
+
+            for i in 1:a_length
+                tmp2[i] = a[i][o]
+            end
+
+            tmp1[o] = sum(sort(tmp2,by=abs))
+        end
+        suma = Taylor1(tmp1,ord)
+    end
+    return suma
+end

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -149,17 +149,24 @@ function evaluate{T<:Number,S<:NumberNotSeriesN}(a::TaylorSeries.TaylorN{T},
     num_vars = get_numvars()
     ct = coeff_table
     R = promote_type(T,S)
-    suma = zero(R)
+    a_length = length(a)
+    suma = zeros(R,a_length)
+    #suma = zero(R)
     for homPol in 1:length(a)
+        sun = zero(R)
         for (i,a_coeff) in enumerate(a.coeffs[homPol].coeffs)
             tmp = vals[1]^(ct[homPol][i][1])
             for n in 2:num_vars
                 tmp *= vals[n]^(ct[homPol][i][n])
             end
-            suma += a_coeff * tmp
+            sun += a_coeff * tmp
+            #println(a_coeff * tmp)
+            #suma += a_coeff * tmp
         end
+        suma[homPol] = sun
     end
 
-    return suma
+    #here it only works with <:Real numbers...
+    return sum(sort(suma))
 end
 evaluate{T<:Number}(a::TaylorN{T}) = a[1][1]

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -114,12 +114,12 @@ end
 
 Evaluate a `HomogeneousPolynomial` polynomial at `vals`.
 """
-function evaluate{T<:Number,S<:TaylorSeries.NumberNotSeriesN}(a::HomogeneousPolynomial{T},
+function evaluate{T<:Number,S<:NumberNotSeriesN}(a::HomogeneousPolynomial{T},
         vals::Array{S,1} )
     @assert length(vals) == get_numvars()
 
     num_vars = get_numvars()
-    ct = TaylorSeries.coeff_table[a.order+1]
+    ct = coeff_table[a.order+1]
     R = promote_type(T,S)
     suma = zero(R)
 
@@ -142,12 +142,12 @@ evaluate(a::HomogeneousPolynomial) = zero(a[1])
 Evaluate the `TaylorN` polynomial `a` at `vals`.
 If `vals` is ommitted, it's evaluated at zero.
 """
-function evaluate{T<:Number,S<:TaylorSeries.NumberNotSeriesN}(a::TaylorSeries.TaylorN{T},
+function evaluate{T<:Number,S<:NumberNotSeriesN}(a::TaylorSeries.TaylorN{T},
         vals::Array{S,1})
     @assert length(vals) == get_numvars()
 
     num_vars = get_numvars()
-    ct = TaylorSeries.coeff_table
+    ct = coeff_table
     R = promote_type(T,S)
     suma = zero(R)
     for homPol in 1:length(a)

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -235,7 +235,7 @@ using Base.Test
     @test imag((exp(yT))^(-1im)') == sin(yT)
     exy = exp( xT+yT )
     @test evaluate(exy) == 1
-    @test evaluate(exy,[0.1im,0.01im]) == exp(0.11im)
+    @test isapprox(evaluate(exy,[0.1im,0.01im]), exp(0.11im))
     @test isapprox(evaluate(exy, [1,1]), e^2)
     txy = tan(xT+yT)
     @test get_coeff(txy,[8,7]) == 929569/99225

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -235,7 +235,7 @@ using Base.Test
     @test imag((exp(yT))^(-1im)') == sin(yT)
     exy = exp( xT+yT )
     @test evaluate(exy) == 1
-    @test isapprox(evaluate(exy,[0.1im,0.01im]), exp(0.11im))
+    @test evaluate(exy,[0.1im,0.01im]) == exp(0.11im)
     @test isapprox(evaluate(exy, [1,1]), e^2)
     txy = tan(xT+yT)
     @test get_coeff(txy,[8,7]) == 929569/99225


### PR DESCRIPTION
I've been working with `TaylorSeries` and `TaylorIntegration` in getting neighborhood solutions of dynamical systems using Jet Transport. This method requieres **a lot** of evaluations of `TaylorN` polynomials and actual `evaluate` methods is really slow. 

This PR changes the `TaylorN` and `HomogeneousPolynomial`  `evaluate` method into a mucho faster one without using Horner's method. I've tried it for `TaylorN`s of 2,3 & 4 variables at `order=7` & `order=14` and benchmarks are inspiring.
Here's an example:

```julia
#evaluate2 is my new evaluate function; evaluate is the actual TaylorSeries one.
julia> x = TaylorN([HomogeneousPolynomial([2,0.]),
             HomogeneousPolynomial([3.,2,1]),
             HomogeneousPolynomial([1.,2,3,4]),
             HomogeneousPolynomial([1,2,3,4,5.]),
             HomogeneousPolynomial([1,2,3,4,5.,6]),
             HomogeneousPolynomial([1,2,3,4,5.,6,7]),         
            ]);
julia> vars = 2; dx = ones(vars);
julia> ex = Taylor1(rand(12)); dxT = [ex,ex];

julia> @time evaluate2(x,dx) 
  0.000006 seconds (5 allocations: 176 bytes)
82.0
julia> @time evaluate(x,dx)
  0.001045 seconds (16.77 k allocations: 934.188 KB)
82.0
julia> @time evaluate2(x,dxT)
  0.000054 seconds (377 allocations: 33.859 KB)
82.0 + 754.0 t + 4155.0 t² + 17300.0 t³ + 57252.2 t⁴ + 158232.4 t⁵ + 373441.9 t⁶ + 759991.4 t⁷ + 1.3505463599999999e6 t⁸ + 2.0965756999999997e6 t⁹ + 2.84503888e6 t¹⁰ + 3.3817241e6 t¹¹ + 𝒪(t¹²)
julia> @time evaluate(x,dxT)
  0.003382 seconds (82.87 k allocations: 5.112 MB)
82.0 + 754.0 t + 4155.0 t² + 17300.0 t³ + 57252.2 t⁴ + 158232.39999999997 t⁵ + 373441.9 t⁶ + 759991.4 t⁷ + 1.35054636e6 t⁸ + 2.0965757000000002e6 t⁹ + 2.8450388800000004e6 t¹⁰ + 3.3817241e6 t¹¹ + 𝒪(t¹²)
``` 
Although allocation and time gets considerably better (which is, I think, because of Horner's rule not being efficient in a many variable evaluation), there is little rounding precision difference

```julia
julia> set_variables("x", numvars=2, order=17);
julia> xH = HomogeneousPolynomial([1,0]); yH = HomogeneousPolynomial([0,1],1); xT = TaylorN(xH, 17); yT = TaylorN(Int64, 2, order=17)
julia> exy = exp( xT+yT );

julia> evaluate2(exy,[0.1im,0.01im])
0.9939560979566969 + 0.10977830083717484im
julia> exp(0.11im) 
0.9939560979566968 + 0.10977830083717481im
```