### PR TITLE
Add missing methods for add! and subst!

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -116,6 +116,10 @@ for (f, fc) in ((:+, :(add!)), (:-, :(subst!)))
                 @inbounds v[k+1] = ($f)(a[k+1])
                 return nothing
             end
+            function ($fc)(v::$T, a::NumberNotSeries, k::Int)
+                @inbounds v[k+1] = k==0 ? ($f)(a) : zero(v[k+1])
+                return nothing
+            end
             function ($fc)(v::$T, a::$T, b::$T, k::Int)
                 @inbounds v[k+1] = ($f)(a[k+1], b[k+1])
                 return nothing

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -263,8 +263,16 @@ using Base.Test
     xx = 1.0*zeroT
     TaylorSeries.add!(xx, 1.0*xT, 2yT, 1)
     @test xx[2] == HomogeneousPolynomial([1,2])
+    TaylorSeries.add!(xx, 5.0, 0)
+    @test xx[1] == HomogeneousPolynomial([5.0])
+    TaylorSeries.add!(xx, -5.0, 1)
+    @test xx[2] == zero(xx[2])
     TaylorSeries.subst!(xx, 1.0*xT, yT, 1)
     @test xx[2] == HomogeneousPolynomial([1,-1])
+    TaylorSeries.subst!(xx, 5.0, 0)
+    @test xx[1] == HomogeneousPolynomial([-5.0])
+    TaylorSeries.subst!(xx, -5.0, 1)
+    @test xx[2] == zero(xx[2])
     TaylorSeries.div!(xx, 1.0+xT, 1.0+xT, 0)
     @test xx[1] == 1.0
     TaylorSeries.pow!(xx, 1.0+xT, 1.5, 0)

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -180,7 +180,15 @@ using Base.Test
     tt = zero(ut)
     TaylorSeries.add!(tt, ut, ut, 1)
     @test tt[2] == 2.0
+    TaylorSeries.add!(tt, -3.0, 0)
+    @test tt[1] == -3.0
+    TaylorSeries.add!(tt, -3.0, 1)
+    @test tt[2] == 0.0
     TaylorSeries.subst!(tt, ut, ut, 1)
+    @test tt[2] == 0.0
+    TaylorSeries.subst!(tt, -3.0, 0)
+    @test tt[1] == 3.0
+    TaylorSeries.subst!(tt, -2.5, 1)
     @test tt[2] == 0.0
     iind, cind = TaylorSeries.divfactorization(ut, ut)
     @test iind == 1


### PR DESCRIPTION
This PR adds some methods for `add!` and `subst!`, such as `add!(v::Taylor1,a::NumberNotSeries,k::Int)`, and analogous versions for `TaylorN`s, which come in handy when working together with PerezHz/TaylorIntegration.jl#31