### PR TITLE
taylor_expand function for Taylor1 and TaylorN 

### DIFF
--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -47,7 +47,7 @@ export get_coeff, derivative, integrate,
     get_order, get_numvars,
     set_variables, get_variables,
     ∇, jacobian, jacobian!, hessian, hessian!,
-    taylor_expand, @taylor_expand, @taylor_expandN
+    taylor_expand
 
 include("parameters.jl")
 include("hash_tables.jl")

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -46,7 +46,8 @@ export get_coeff, derivative, integrate,
     show_params_TaylorN,
     get_order, get_numvars,
     set_variables, get_variables,
-    ∇, jacobian, jacobian!, hessian, hessian!
+    ∇, jacobian, jacobian!, hessian, hessian!,
+    taylor_expand, @taylor_expand, @taylor_expandN
 
 include("parameters.jl")
 include("hash_tables.jl")

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -47,7 +47,7 @@ export get_coeff, derivative, integrate,
     get_order, get_numvars,
     set_variables, get_variables,
     ∇, jacobian, jacobian!, hessian, hessian!,
-    taylor_expand, taylor_expand!
+    taylor_expand, update!
 
 include("parameters.jl")
 include("hash_tables.jl")

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -47,7 +47,7 @@ export get_coeff, derivative, integrate,
     get_order, get_numvars,
     set_variables, get_variables,
     ∇, jacobian, jacobian!, hessian, hessian!,
-    taylor_expand
+    taylor_expand, taylor_expand!
 
 include("parameters.jl")
 include("hash_tables.jl")

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -202,16 +202,15 @@ function evaluate{T<:Number,S<:NumberNotSeries}(a::TaylorN{T},
     @assert length(vals) == get_numvars()
 
     num_vars = get_numvars()
-    ct = coeff_table
     R = promote_type(T,S)
     a_length = length(a)
     suma = zeros(R,a_length)
     for homPol in 1:length(a)
         sun = zero(R)
         for (i,a_coeff) in enumerate(a.coeffs[homPol].coeffs)
-            tmp = vals[1]^(ct[homPol][i][1])
+            tmp = vals[1]^(coeff_table[homPol][i][1])
             for n in 2:num_vars
-                tmp *= vals[n]^(ct[homPol][i][n])
+                tmp *= vals[n]^(coeff_table[homPol][i][n])
             end
             sun += a_coeff * tmp
         end
@@ -226,7 +225,6 @@ function evaluate{T<:Number,S<:NumberNotSeries}(a::TaylorN{T},
     @assert length(vals) == get_numvars()
 
     num_vars = get_numvars()
-    ct = coeff_table
     R = promote_type(T,S)
     a_length = length(a)
     ord = maximum( get_order.(vals) )
@@ -234,9 +232,9 @@ function evaluate{T<:Number,S<:NumberNotSeries}(a::TaylorN{T},
 
     for homPol in 1:length(a)
         for (i,a_coeff) in enumerate(a.coeffs[homPol].coeffs)
-            tmp = vals[1]^(ct[homPol][i][1])
+            tmp = vals[1]^(coeff_table[homPol][i][1])
             for n in 2:num_vars
-                tmp *= vals[n]^(ct[homPol][i][n])
+                tmp *= vals[n]^(coeff_table[homPol][i][n])
             end
             suma += a_coeff * tmp
         end
@@ -250,16 +248,15 @@ function evaluate{T<:NumberNotSeries}(a::TaylorN{Taylor1{T}},
     @assert length(vals) == get_numvars()
 
     num_vars = get_numvars()
-    ct = coeff_table
     a_length = length(a)
     ord = maximum( get_order.(vals) )
     suma = Taylor1(zeros(T, ord))
 
     for homPol in 1:length(a)
         for (i,a_coeff) in enumerate(a.coeffs[homPol].coeffs)
-            tmp = vals[1]^(ct[homPol][i][1])
+            tmp = vals[1]^(coeff_table[homPol][i][1])
             for n in 2:num_vars
-                tmp *= vals[n]^(ct[homPol][i][n])
+                tmp *= vals[n]^(coeff_table[homPol][i][n])
             end
             suma += a_coeff * tmp
         end
@@ -273,7 +270,6 @@ function evaluate{T<:Number,S<:NumberNotSeries}(a::TaylorN{T},
     @assert length(vals) == get_numvars()
 
     num_vars = get_numvars()
-    ct = coeff_table
     R = promote_type(T,eltype(S))
     a_length = length(a)
     ord = maximum( get_order.(vals) )
@@ -281,9 +277,9 @@ function evaluate{T<:Number,S<:NumberNotSeries}(a::TaylorN{T},
 
     for homPol in 1:length(a)
         for (i,a_coeff) in enumerate(a.coeffs[homPol].coeffs)
-            tmp = vals[1]^(ct[homPol][i][1])
+            tmp = vals[1]^(coeff_table[homPol][i][1])
             for n in 2:num_vars
-                tmp *= vals[n]^(ct[homPol][i][n])
+                tmp *= vals[n]^(coeff_table[homPol][i][n])
             end
             suma += a_coeff * tmp
         end

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -79,7 +79,7 @@ function evaluate!{T<:Number, S<:Number}(x::Array{Taylor1{T},1}, δt::S, x0::Uni
     nothing
 end
 
-"""
+doc"""
     evaluate(a, x)
 
 Substitute `x::Taylor1` as independent variable in a `a::Taylor1` polynomial.
@@ -155,7 +155,7 @@ function evaluate!{T<:Number}(x::Array{Taylor1{TaylorN{T}},1}, δt::T,
     nothing
 end
 
-"""
+doc"""
     evaluate(a, [vals])
 
 Evaluate a `HomogeneousPolynomial` polynomial at `vals`. If `vals` is ommitted,
@@ -189,7 +189,7 @@ evaluate(a::HomogeneousPolynomial) = zero(a[1])
 
 (p::HomogeneousPolynomial)() = evaluate(p)
 
-"""
+doc"""
     evaluate(a, [vals])
 
 Evaluate the `TaylorN` polynomial `a` at `vals`.

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -192,35 +192,21 @@ function taylor_expand{T<:Number}(f::Function, x0::T; order::Int64=15)
 end
 
 #taylor_expand function for TaylorN
-function taylor_expand{T<:Number}(f::Function, x0::Vector{T}; order::Int64=get_order())
+function taylor_expand{T<:Number}(f::Function, x0::Vector{T}; order::Int64=get_order()) #a Taylor expansion around x0
     ll = length(x0)
-    X = set_variables("x",order=order,numvars=ll)
-
+    ll == get_numvars() ? X = get_variables() : begin
+        X = set_variables("x",order=order,numvars=ll)
+        warn("Changed number of TaylorN variables to $ll.")
+        end
     return f(X.+x0)
 end
 
-#taylor_expand macro for Taylor1
-macro taylor_expand(f, order::Int64=get_order())
-    @eval begin
-       a = Taylor1($order)
-       return $f(a)
-    end
-end
+function taylor_expand(f::Function, x0...; order::Int64=get_order()) #a Taylor expansion around x0
+    ll = length(x0)
+    ll == get_numvars() ? X = get_variables() : begin
+        X = set_variables("x",order=order,numvars=ll)
+        warn("Changed number of TaylorN variables to $ll.")
+        end
 
-macro taylor_expand(f, x0, order::Int64=get_order())
-    @eval begin
-       a = Taylor1([$x0, one($x0)], $order)
-       return $f(a)
-    end
-end
-
-#taylor_expandN macro for TaylorN
-macro taylor_expandN(f, x0, order::Int64=get_order())#a Taylor expansion around x0
-    @eval begin
-    ll = length($x0)
-    X = set_variables("x",order=$order,numvars=ll)
-
-    return $f(X.+ $x0)
-    end
-
+    return f(x0 .+ X...)
 end

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -212,15 +212,23 @@ function taylor_expand(f::Function, x0...; order::Int64=get_order()) #a Taylor e
 end
 
 #taylor_expand! function for Taylor1
-function taylor_expand!(t::Taylor1)
+function taylor_expand!(a::Taylor1)
     #shifting around zero shouldn't change anything...
     nothing
 end
 
-function taylor_expand{T<:Number}!(t::Taylor1, x0::T)
-    tsq.coeffs .= evaluate(t, Taylor1([x0,one(x0)], t.order) ).coeffs
+function taylor_expand!{T<:Number}(a::Taylor1, x0::T)
+    a.coeffs .= evaluate(a, Taylor1([x0,one(x0)], a.order) ).coeffs
     nothing
 end
 
-#ToDo
-#taylor_expand! function for TaylorN  (evaluate(TaylorN,Vector{TaylorN}) is required...)
+#taylor_expand! function for TaylorN
+function taylor_expand!{T<:Number}(a::TaylorN,vals::Vector{T})
+    a.coeffs .= evaluate(a,get_variables().+vals).coeffs
+    nothing
+end
+
+function taylor_expand!(a::TaylorN)
+    #shifting around zero shouldn't change anything...
+    nothing
+end

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -178,10 +178,11 @@ polynomials. For more details, see [`Base.isapprox`](@ref).
 """
 function isapprox{T<:AbstractSeries,S<:AbstractSeries}(x::T, y::S; rtol::Real=rtoldefault(x,y), atol::Real=0, nans::Bool=false)
     x == y || (isfinite(x) && isfinite(y) && norm(x-y,1) <= atol + rtol*max(norm(x,1), norm(y,1))) || (nans && isnan(x) && isnan(y))
+end
 
 
 #taylor_expand function for Taylor1
-"""
+doc"""
     taylor_expand(f,x0;order)
 
 Makes a Taylor expansion of the function `f` around the point `x0`. If x0 is a scalar,
@@ -220,7 +221,7 @@ function taylor_expand(f::Function, x0...; order::Int64=get_order()) #a Taylor e
 end
 
 #taylor_expand! function for Taylor1
-"""
+doc"""
     taylor_expand!(a,x0;order)
 
 Takes `a <: Union{Taylo1,TaylorN}` and expands it around the coordinate `x0`.

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -183,12 +183,12 @@ end
 
 #taylor_expand function for Taylor1
 doc"""
-    taylor_expand(f,x0;order)
+    taylor_expand(f ,x0 ;order)
 
 Makes a Taylor expansion of the function `f` around the point `x0`. If x0 is a scalar,
 a `Taylor1` expansion will be done. If `x0` is a vector, a `TaylorN` expansion will be
-computed, changing the number of `TaylorN` variables
-according to the dimension of `f`.
+computed. If the dimension of x0 (`length(x0)`) is different from the variables set for
+`TaylorN` (`get_numvars()`), an `AssertionError` will be thrown.
 """
 function taylor_expand(f::Function; order::Int64=15)
    a = Taylor1(order)

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -226,29 +226,24 @@ function taylor_expand(f::Function, x0...; order::Int64=get_order()) #a Taylor e
     return f(x0 .+ X...)
 end
 
-#taylor_expand! function for Taylor1
+#update! function for Taylor1
 doc"""
-    taylor_expand!(a,x0;order)
+    update!(a,x0;order)
 
 Takes `a <: Union{Taylo1,TaylorN}` and expands it around the coordinate `x0`.
 """
-function taylor_expand!(a::Taylor1)
-    #shifting around zero shouldn't change anything...
-    nothing
-end
-
-function taylor_expand!{T<:Number}(a::Taylor1, x0::T)
+function update!{T<:Number}(a::Taylor1, x0::T)
     a.coeffs .= evaluate(a, Taylor1([x0,one(x0)], a.order) ).coeffs
     nothing
 end
 
-#taylor_expand! function for TaylorN
-function taylor_expand!{T<:Number}(a::TaylorN,vals::Vector{T})
+#update! function for TaylorN
+function update!{T<:Number}(a::TaylorN,vals::Vector{T})
     a.coeffs .= evaluate(a,get_variables().+vals).coeffs
     nothing
 end
 
-function taylor_expand!(a::TaylorN)
+function update!(a::Union{Taylor1,TaylorN})
     #shifting around zero shouldn't change anything...
     nothing
 end

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -203,19 +203,25 @@ end
 #taylor_expand function for TaylorN
 function taylor_expand{T<:Number}(f::Function, x0::Vector{T}; order::Int64=get_order()) #a Taylor expansion around x0
     ll = length(x0)
-    ll == get_numvars() ? X = get_variables() : begin
-        X = set_variables("x",order=order,numvars=ll)
-        warn("Changed number of TaylorN variables to $ll.")
-        end
-    return f(X.+x0)
+    @assert ll == get_numvars() && order <= get_order()
+    X = Array{TaylorN{T}}(ll)
+
+    for i in eachindex(X)
+        X[i] = TaylorN(T, i, order=order)
+    end
+
+    return f(X .+ x0)
 end
 
 function taylor_expand(f::Function, x0...; order::Int64=get_order()) #a Taylor expansion around x0
+    T = eltype(x0[1])
     ll = length(x0)
-    ll == get_numvars() ? X = get_variables() : begin
-        X = set_variables("x",order=order,numvars=ll)
-        warn("Changed number of TaylorN variables to $ll.")
-        end
+    @assert ll == get_numvars() && order <= get_order()
+    X = Array{TaylorN{T}}(ll)
+
+    for i in eachindex(X)
+        X[i] = TaylorN(T, i, order=order)
+    end
 
     return f(x0 .+ X...)
 end

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -181,6 +181,14 @@ function isapprox{T<:AbstractSeries,S<:AbstractSeries}(x::T, y::S; rtol::Real=rt
 
 
 #taylor_expand function for Taylor1
+"""
+    taylor_expand(f,x0;order)
+
+Makes a Taylor expansion of the function `f` around the point `x0`. If x0 is a scalar,
+a `Taylor1` expansion will be done. If `x0` is a vector, a `TaylorN` expansion will be
+computed, changing the number of `TaylorN` variables
+according to the dimension of `f`.
+"""
 function taylor_expand(f::Function; order::Int64=15)
    a = Taylor1(order)
    return f(a)
@@ -212,6 +220,11 @@ function taylor_expand(f::Function, x0...; order::Int64=get_order()) #a Taylor e
 end
 
 #taylor_expand! function for Taylor1
+"""
+    taylor_expand!(a,x0;order)
+
+Takes `a <: Union{Taylo1,TaylorN}` and expands it around the coordinate `x0`.
+"""
 function taylor_expand!(a::Taylor1)
     #shifting around zero shouldn't change anything...
     nothing

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -210,3 +210,17 @@ function taylor_expand(f::Function, x0...; order::Int64=get_order()) #a Taylor e
 
     return f(x0 .+ X...)
 end
+
+#taylor_expand! function for Taylor1
+function taylor_expand!(t::Taylor1)
+    #shifting around zero shouldn't change anything...
+    nothing
+end
+
+function taylor_expand{T<:Number}!(t::Taylor1, x0::T)
+    tsq.coeffs .= evaluate(t, Taylor1([x0,one(x0)], t.order) ).coeffs
+    nothing
+end
+
+#ToDo
+#taylor_expand! function for TaylorN  (evaluate(TaylorN,Vector{TaylorN}) is required...)

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -129,6 +129,7 @@ function abs{T<:Real}(a::Taylor1{TaylorN{T}})
         (abs(x) is not differentiable at x=0)."""))
     end
 end
+
 doc"""
     abs(a)
 
@@ -177,4 +178,49 @@ polynomials. For more details, see [`Base.isapprox`](@ref).
 """
 function isapprox{T<:AbstractSeries,S<:AbstractSeries}(x::T, y::S; rtol::Real=rtoldefault(x,y), atol::Real=0, nans::Bool=false)
     x == y || (isfinite(x) && isfinite(y) && norm(x-y,1) <= atol + rtol*max(norm(x,1), norm(y,1))) || (nans && isnan(x) && isnan(y))
+
+
+#taylor_expand function for Taylor1
+function taylor_expand(f::Function, order::Int64=get_order())
+   a = Taylor1(order)
+   return f(a)
+end
+
+function taylor_expand{T<:Number}(f::Function, x0::T, order::Int64=get_order())
+   a = Taylor1([x0, one(T)], order)
+   return f(a)
+end
+
+#taylor_expand function for TaylorN
+function taylor_expand{T<:Number}(f::Function, x0::Vector{T}, order::Int64=get_order())
+    ll = length(x0)
+    X = set_variables("x",order=order,numvars=ll)
+
+    return f(X.+x0)
+end
+
+#taylor_expand macro for Taylor1
+macro taylor_expand(f, order::Int64=get_order())
+    @eval begin
+       a = Taylor1($order)
+       return $f(a)
+    end
+end
+
+macro taylor_expand(f, x0, order::Int64=get_order())
+    @eval begin
+       a = Taylor1([$x0, one($x0)], $order)
+       return $f(a)
+    end
+end
+
+#taylor_expandN macro for TaylorN
+macro taylor_expandN(f, x0, order::Int64=get_order())#a Taylor expansion around x0
+    @eval begin
+    ll = length($x0)
+    X = set_variables("x",order=$order,numvars=ll)
+
+    return $f(X.+ $x0)
+    end
+
 end

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -207,23 +207,24 @@ function taylor_expand{T<:Number}(f::Function, x0::Vector{T}; order::Int64=get_o
     X = Array{TaylorN{T}}(ll)
 
     for i in eachindex(X)
-        X[i] = TaylorN(T, i, order=order)
+        X[i] = x0[i] + TaylorN(T, i, order=order)
     end
 
-    return f(X .+ x0)
+    return f( X )
 end
 
 function taylor_expand(f::Function, x0...; order::Int64=get_order()) #a Taylor expansion around x0
+    x0 = promote(x0...)
     T = eltype(x0[1])
     ll = length(x0)
     @assert ll == get_numvars() && order <= get_order()
     X = Array{TaylorN{T}}(ll)
 
     for i in eachindex(X)
-        X[i] = TaylorN(T, i, order=order)
+        X[i] = x0[i] + TaylorN(T, i, order=order)
     end
 
-    return f(x0 .+ X...)
+    return f( X... )
 end
 
 #update! function for Taylor1

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -181,18 +181,18 @@ function isapprox{T<:AbstractSeries,S<:AbstractSeries}(x::T, y::S; rtol::Real=rt
 
 
 #taylor_expand function for Taylor1
-function taylor_expand(f::Function, order::Int64=get_order())
+function taylor_expand(f::Function; order::Int64=15)
    a = Taylor1(order)
    return f(a)
 end
 
-function taylor_expand{T<:Number}(f::Function, x0::T, order::Int64=get_order())
+function taylor_expand{T<:Number}(f::Function, x0::T; order::Int64=15)
    a = Taylor1([x0, one(T)], order)
    return f(a)
 end
 
 #taylor_expand function for TaylorN
-function taylor_expand{T<:Number}(f::Function, x0::Vector{T}, order::Int64=get_order())
+function taylor_expand{T<:Number}(f::Function, x0::Vector{T}; order::Int64=get_order())
     ll = length(x0)
     X = set_variables("x",order=order,numvars=ll)
 

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -386,11 +386,13 @@ end
     f22(a) = (a[1] + a[2])^a[1] - cos(a[1]*a[2])*a[2]
     @test taylor_expand(f11,1.,2.) == taylor_expand(f22,[1,2.])
     @test evaluate(taylor_expand(x->x[1] + x[2],[1,2])) == 3.0
+    f33(x,y) = 3x+y
+    @test eltype(taylor_expand(f33,1,1)) == eltype(1)
     x,y = get_variables()
     xysq = x^2 + y^2
-    taylor_expand!(xysq,[1.0,-2.0])
+    update!(xysq,[1.0,-2.0])
     @test xysq == (x+1.0)^2 + (y-2.0)^2
-    taylor_expand!(xysq,[-1.0,2.0])
+    update!(xysq,[-1.0,2.0])
     @test xysq == x^2 + y^2
 
     #test function-like behavior for TaylorN

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -413,11 +413,16 @@ end
     @test Q[1:3]() == evaluate(Q[1:3])
 
     #obs: taylor_expand uses set_variables internally.
-    f1(x,y) = (x+y)^x - cos(x*y)*y
-    f2(x) = (x[1] + x[2])^x[1] - cos(x[1]*x[2])*x[2]
+    f1(a,b) = (a+b)^a - cos(a*b)*b
+    f2(a) = (a[1] + a[2])^a[1] - cos(a[1]*a[2])*a[2]
     @test taylor_expand(f1,1.,2.) == taylor_expand(f2,[1,2.])
-    @test taylor_expand(exp,[0,0.]) == [exp(get_variables()[1]),exp(get_variables()[2])]
     @test evaluate(taylor_expand(x->x[1] + x[2],[1,2])) == 3.0
+    x,y = get_variables()
+    xysq = x^2 + y^2
+    taylor_expand!(xysq,[1.0,-2.0])
+    @test xysq == (x+1.0)^2 + (y-2.0)^2
+    taylor_expand!(xysq,[-1.0,2.0])
+    @test xysq == x^2 + y^2
 
     #test function-like behavior for TaylorN
     @test exy() == 1

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -413,7 +413,10 @@ end
     @test Q[1:3]() == evaluate(Q[1:3])
 
     #obs: taylor_expand uses set_variables internally.
-    @test taylor_expand(exp,[0,0.]) == exp.(set_variables("x",numvars=2))
+    f1(x,y) = (x+y)^x - cos(x*y)*y
+    f2(x) = (x[1] + x[2])^x[1] - cos(x[1]*x[2])*x[2]
+    @test taylor_expand(f1,1.,2.) == taylor_expand(f2,[1,2.])
+    @test taylor_expand(exp,[0,0.]) == exp(get_variables())
     @test evaluate(taylor_expand(x->x[1] + x[2],[1,2])) == 3.0
 
 end

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -411,4 +411,9 @@ end
     @test Q() == evaluate.(Q)
     @test Q() == evaluate(Q)
     @test Q[1:3]() == evaluate(Q[1:3])
+
+    #obs: taylor_expand uses set_variables internally.
+    @test taylor_expand(exp,[0,0.]) == exp.(set_variables("x",numvars=2))
+    @test evaluate(taylor_expand(x->x[1] + x[2],[1,2])) == 3.0
+
 end

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -419,4 +419,33 @@ end
     @test taylor_expand(exp,[0,0.]) == [exp(get_variables()[1]),exp(get_variables()[2])]
     @test evaluate(taylor_expand(x->x[1] + x[2],[1,2])) == 3.0
 
+    #test function-like behavior for TaylorN
+    @test exy() == 1
+    @test exy([0.1im,0.01im]) == exp(0.11im)
+    @test isapprox(exy([1,1]), e^2)
+    @test sin(asin(xT+yT))([1.0,0.5]) == 1.5
+    @test asin(sin(xT+yT))([1.0,0.5]) == 1.5
+    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(rand(2)) == 1
+    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(zeros(2)) == 1
+    dx = set_variables("x", numvars=4, order=10)
+    P = sin.(dx)
+    v = [1.0,2,3,4]
+    for i in 1:4
+        @test P[i](v) == evaluate(P[i], v)
+    end
+    @test P.(fill(v, 4)) == fill(P(v), 4)
+    F(x) = [sin(sin(x[4]+x[3])), sin(cos(x[3]-x[2])), cos(sin(x[1]^2+x[2]^2)), cos(cos(x[2]*x[3]))]
+    Q = F(v+dx)
+    @test Q.( fill(v, 4) ) == fill(Q(v), 4)
+    vr = map(x->rand(4), 1:4)
+    @test Q.(vr) == map(x->Q(x), vr)
+    for i in 1:4
+        @test P[i]() == evaluate(P[i])
+        @test Q[i]() == evaluate(Q[i])
+    end
+    @test P() == evaluate.(P)
+    @test P() == evaluate(P)
+    @test Q() == evaluate.(Q)
+    @test Q() == evaluate(Q)
+    @test Q[1:3]() == evaluate(Q[1:3])
 end

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -352,36 +352,6 @@ end
     @test_throws BoundsError xH[20]
     @test_throws BoundsError xT[20]
 
-    #test function-like behavior for TaylorN
-    @test exy() == 1
-    @test exy([0.1im,0.01im]) == exp(0.11im)
-    @test isapprox(exy([1,1]), e^2)
-    @test sin(asin(xT+yT))([1.0,0.5]) == 1.5
-    @test asin(sin(xT+yT))([1.0,0.5]) == 1.5
-    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(rand(2)) == 1
-    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(zeros(2)) == 1
-    dx = set_variables("x", numvars=4, order=10)
-    P = sin.(dx)
-    v = [1.0,2,3,4]
-    for i in 1:4
-        @test P[i](v) == evaluate(P[i], v)
-    end
-    @test P.(fill(v, 4)) == fill(P(v), 4)
-    F(x) = [sin(sin(x[4]+x[3])), sin(cos(x[3]-x[2])), cos(sin(x[1]^2+x[2]^2)), cos(cos(x[2]*x[3]))]
-    Q = F(v+dx)
-    @test Q.( fill(v, 4) ) == fill(Q(v), 4)
-    vr = map(x->rand(4), 1:4)
-    @test Q.(vr) == map(x->Q(x), vr)
-    for i in 1:4
-        @test P[i]() == evaluate(P[i])
-        @test Q[i]() == evaluate(Q[i])
-    end
-    @test P() == evaluate.(P)
-    @test P() == evaluate(P)
-    @test Q() == evaluate.(Q)
-    @test Q() == evaluate(Q)
-    @test Q[1:3]() == evaluate(Q[1:3])
-
     a = 3x + 4y +6x^2 + 8x*y
     @test typeof( norm(x) ) == Float64
     @test norm(x) > 0
@@ -412,10 +382,9 @@ end
     @test a[2] ≈ b[2]
     @test a ≈ b
 
-    #obs: taylor_expand uses set_variables internally.
-    f1(a,b) = (a+b)^a - cos(a*b)*b
-    f2(a) = (a[1] + a[2])^a[1] - cos(a[1]*a[2])*a[2]
-    @test taylor_expand(f1,1.,2.) == taylor_expand(f2,[1,2.])
+    f11(a,b) = (a+b)^a - cos(a*b)*b
+    f22(a) = (a[1] + a[2])^a[1] - cos(a[1]*a[2])*a[2]
+    @test taylor_expand(f11,1.,2.) == taylor_expand(f22,[1,2.])
     @test evaluate(taylor_expand(x->x[1] + x[2],[1,2])) == 3.0
     x,y = get_variables()
     xysq = x^2 + y^2
@@ -423,4 +392,35 @@ end
     @test xysq == (x+1.0)^2 + (y-2.0)^2
     taylor_expand!(xysq,[-1.0,2.0])
     @test xysq == x^2 + y^2
+
+    #test function-like behavior for TaylorN
+    @test exy() == 1
+    @test exy([0.1im,0.01im]) == exp(0.11im)
+    @test isapprox(exy([1,1]), e^2)
+    @test sin(asin(xT+yT))([1.0,0.5]) == 1.5
+    @test asin(sin(xT+yT))([1.0,0.5]) == 1.5
+    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(rand(2)) == 1
+    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(zeros(2)) == 1
+    #number of variables changed to 4...
+    dx = set_variables("x", numvars=4, order=10)
+    P = sin.(dx)
+    v = [1.0,2,3,4]
+    for i in 1:4
+        @test P[i](v) == evaluate(P[i], v)
+    end
+    @test P.(fill(v, 4)) == fill(P(v), 4)
+    F(x) = [sin(sin(x[4]+x[3])), sin(cos(x[3]-x[2])), cos(sin(x[1]^2+x[2]^2)), cos(cos(x[2]*x[3]))]
+    Q = F(v+dx)
+    @test Q.( fill(v, 4) ) == fill(Q(v), 4)
+    vr = map(x->rand(4), 1:4)
+    @test Q.(vr) == map(x->Q(x), vr)
+    for i in 1:4
+        @test P[i]() == evaluate(P[i])
+        @test Q[i]() == evaluate(Q[i])
+    end
+    @test P() == evaluate.(P)
+    @test P() == evaluate(P)
+    @test Q() == evaluate.(Q)
+    @test Q() == evaluate(Q)
+    @test Q[1:3]() == evaluate(Q[1:3])
 end

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -337,6 +337,51 @@ end
     hessian!(hes2,g1(xT+1,yT-1)-g2(xT+1,yT-1))
     @test hes1 == hes2
 
+    @test string(-xH) == " - 1 x₁"
+    @test string(xT^2) == " 1 x₁² + 𝒪(‖x‖¹⁸)"
+    @test string(1im*yT) == " ( 1 im ) x₂ + 𝒪(‖x‖¹⁸)"
+    @test string(xT-im*yT) == "  ( 1 ) x₁ - ( 1 im ) x₂ + 𝒪(‖x‖¹⁸)"
+
+    @test_throws ArgumentError abs(xT)
+    @test_throws AssertionError 1/x
+    @test_throws AssertionError zero(x)/zero(x)
+    @test_throws ArgumentError sqrt(x)
+    @test_throws AssertionError x^(-2)
+    @test_throws ArgumentError log(x)
+    @test_throws AssertionError cos(x)/sin(y)
+    @test_throws BoundsError xH[20]
+    @test_throws BoundsError xT[20]
+
+    #test function-like behavior for TaylorN
+    @test exy() == 1
+    @test exy([0.1im,0.01im]) == exp(0.11im)
+    @test isapprox(exy([1,1]), e^2)
+    @test sin(asin(xT+yT))([1.0,0.5]) == 1.5
+    @test asin(sin(xT+yT))([1.0,0.5]) == 1.5
+    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(rand(2)) == 1
+    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(zeros(2)) == 1
+    dx = set_variables("x", numvars=4, order=10)
+    P = sin.(dx)
+    v = [1.0,2,3,4]
+    for i in 1:4
+        @test P[i](v) == evaluate(P[i], v)
+    end
+    @test P.(fill(v, 4)) == fill(P(v), 4)
+    F(x) = [sin(sin(x[4]+x[3])), sin(cos(x[3]-x[2])), cos(sin(x[1]^2+x[2]^2)), cos(cos(x[2]*x[3]))]
+    Q = F(v+dx)
+    @test Q.( fill(v, 4) ) == fill(Q(v), 4)
+    vr = map(x->rand(4), 1:4)
+    @test Q.(vr) == map(x->Q(x), vr)
+    for i in 1:4
+        @test P[i]() == evaluate(P[i])
+        @test Q[i]() == evaluate(Q[i])
+    end
+    @test P() == evaluate.(P)
+    @test P() == evaluate(P)
+    @test Q() == evaluate.(Q)
+    @test Q() == evaluate(Q)
+    @test Q[1:3]() == evaluate(Q[1:3])
+
     a = 3x + 4y +6x^2 + 8x*y
     @test typeof( norm(x) ) == Float64
     @test norm(x) > 0
@@ -367,21 +412,6 @@ end
     @test a[2] ≈ b[2]
     @test a ≈ b
 
-    @test string(-xH) == " - 1 x₁"
-    @test string(xT^2) == " 1 x₁² + 𝒪(‖x‖¹⁸)"
-    @test string(1im*yT) == " ( 1 im ) x₂ + 𝒪(‖x‖¹⁸)"
-    @test string(xT-im*yT) == "  ( 1 ) x₁ - ( 1 im ) x₂ + 𝒪(‖x‖¹⁸)"
-
-    @test_throws ArgumentError abs(xT)
-    @test_throws AssertionError 1/x
-    @test_throws AssertionError zero(x)/zero(x)
-    @test_throws ArgumentError sqrt(x)
-    @test_throws AssertionError x^(-2)
-    @test_throws ArgumentError log(x)
-    @test_throws AssertionError cos(x)/sin(y)
-    @test_throws BoundsError xH[20]
-    @test_throws BoundsError xT[20]
-
     #obs: taylor_expand uses set_variables internally.
     f1(a,b) = (a+b)^a - cos(a*b)*b
     f2(a) = (a[1] + a[2])^a[1] - cos(a[1]*a[2])*a[2]
@@ -393,76 +423,4 @@ end
     @test xysq == (x+1.0)^2 + (y-2.0)^2
     taylor_expand!(xysq,[-1.0,2.0])
     @test xysq == x^2 + y^2
-
-    #test function-like behavior for TaylorN
-    @test exy() == 1
-    @test exy([0.1im,0.01im]) == exp(0.11im)
-    @test isapprox(exy([1,1]), e^2)
-    @test sin(asin(xT+yT))([1.0,0.5]) == 1.5
-    @test asin(sin(xT+yT))([1.0,0.5]) == 1.5
-    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(rand(2)) == 1
-    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(zeros(2)) == 1
-    dx = set_variables("x", numvars=4, order=10)
-    P = sin.(dx)
-    v = [1.0,2,3,4]
-    for i in 1:4
-        @test P[i](v) == evaluate(P[i], v)
-    end
-    @test P.(fill(v, 4)) == fill(P(v), 4)
-    F(x) = [sin(sin(x[4]+x[3])), sin(cos(x[3]-x[2])), cos(sin(x[1]^2+x[2]^2)), cos(cos(x[2]*x[3]))]
-    Q = F(v+dx)
-    @test Q.( fill(v, 4) ) == fill(Q(v), 4)
-    vr = map(x->rand(4), 1:4)
-    @test Q.(vr) == map(x->Q(x), vr)
-    for i in 1:4
-        @test P[i]() == evaluate(P[i])
-        @test Q[i]() == evaluate(Q[i])
-    end
-    @test P() == evaluate.(P)
-    @test P() == evaluate(P)
-    @test Q() == evaluate.(Q)
-    @test Q() == evaluate(Q)
-    @test Q[1:3]() == evaluate(Q[1:3])
-
-    #obs: taylor_expand uses set_variables internally.
-    f1(a,b) = (a+b)^a - cos(a*b)*b
-    f2(a) = (a[1] + a[2])^a[1] - cos(a[1]*a[2])*a[2]
-    @test taylor_expand(f1,1.,2.) == taylor_expand(f2,[1,2.])
-    @test evaluate(taylor_expand(x->x[1] + x[2],[1,2])) == 3.0
-    x,y = get_variables()
-    xysq = x^2 + y^2
-    taylor_expand!(xysq,[1.0,-2.0])
-    @test xysq == (x+1.0)^2 + (y-2.0)^2
-    taylor_expand!(xysq,[-1.0,2.0])
-    @test xysq == x^2 + y^2
-
-    #test function-like behavior for TaylorN
-    @test exy() == 1
-    @test exy([0.1im,0.01im]) == exp(0.11im)
-    @test isapprox(exy([1,1]), e^2)
-    @test sin(asin(xT+yT))([1.0,0.5]) == 1.5
-    @test asin(sin(xT+yT))([1.0,0.5]) == 1.5
-    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(rand(2)) == 1
-    @test ( -sinh(xT+yT)^2 + cosh(xT+yT)^2 )(zeros(2)) == 1
-    dx = set_variables("x", numvars=4, order=10)
-    P = sin.(dx)
-    v = [1.0,2,3,4]
-    for i in 1:4
-        @test P[i](v) == evaluate(P[i], v)
-    end
-    @test P.(fill(v, 4)) == fill(P(v), 4)
-    F(x) = [sin(sin(x[4]+x[3])), sin(cos(x[3]-x[2])), cos(sin(x[1]^2+x[2]^2)), cos(cos(x[2]*x[3]))]
-    Q = F(v+dx)
-    @test Q.( fill(v, 4) ) == fill(Q(v), 4)
-    vr = map(x->rand(4), 1:4)
-    @test Q.(vr) == map(x->Q(x), vr)
-    for i in 1:4
-        @test P[i]() == evaluate(P[i])
-        @test Q[i]() == evaluate(Q[i])
-    end
-    @test P() == evaluate.(P)
-    @test P() == evaluate(P)
-    @test Q() == evaluate.(Q)
-    @test Q() == evaluate(Q)
-    @test Q[1:3]() == evaluate(Q[1:3])
 end

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -416,7 +416,7 @@ end
     f1(x,y) = (x+y)^x - cos(x*y)*y
     f2(x) = (x[1] + x[2])^x[1] - cos(x[1]*x[2])*x[2]
     @test taylor_expand(f1,1.,2.) == taylor_expand(f2,[1,2.])
-    @test taylor_expand(exp,[0,0.]) == exp(get_variables())
+    @test taylor_expand(exp,[0,0.]) == [exp(get_variables()[1]),exp(get_variables()[2])]
     @test evaluate(taylor_expand(x->x[1] + x[2],[1,2])) == 3.0
 
 end

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -159,6 +159,9 @@ end
     @test taylor_expand(x->x^2+1) == Taylor1(15)*Taylor1(15) + 1
     @test evaluate(taylor_expand(cos,0.)) == cos(0.)
     @test evaluate(taylor_expand(tan,pi/4)) == tan(pi/4)
+    tsq = t^2
+    taylor_expand!(tsq,2.0)
+    @test tsq == (t+2.0)^2
 
     @test log(exp(tsquare)) == tsquare
     @test exp(log(1-tsquare)) == 1-tsquare

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -159,10 +159,11 @@ end
     @test taylor_expand(x->x^2+1) == Taylor1(15)*Taylor1(15) + 1
     @test evaluate(taylor_expand(cos,0.)) == cos(0.)
     @test evaluate(taylor_expand(tan,pi/4)) == tan(pi/4)
+    @test eltype(taylor_expand(x->x^2+1,1)) == eltype(1)
     tsq = t^2
-    taylor_expand!(tsq,2.0)
+    update!(tsq,2.0)
     @test tsq == (t+2.0)^2
-    taylor_expand!(tsq,-2.0)
+    update!(tsq,-2.0)
     @test tsq == t^2
 
     @test log(exp(tsquare)) == tsquare

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -154,6 +154,12 @@ end
     @test abs(ta(1)) == ta(1)
     @test abs(ta(-1.0)) == -ta(-1.0)
 
+
+    @test taylor_expand(x->2x,order=10) == 2*Taylor1(10)
+    @test taylor_expand(x->x^2+1) == Taylor1(15)*Taylor1(15) + 1
+    @test evaluate(taylor_expand(cos,0.)) == cos(0.)
+    @test evaluate(taylor_expand(tan,pi/4)) == tan(pi/4)
+
     @test log(exp(tsquare)) == tsquare
     @test exp(log(1-tsquare)) == 1-tsquare
     @test log((1-t)^2) == 2*log(1-t)

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -162,6 +162,8 @@ end
     tsq = t^2
     taylor_expand!(tsq,2.0)
     @test tsq == (t+2.0)^2
+    taylor_expand!(tsq,-2.0)
+    @test tsq == t^2
 
     @test log(exp(tsquare)) == tsquare
     @test exp(log(1-tsquare)) == 1-tsquare


### PR DESCRIPTION
This makes reference to #68. A `taylor_expand` function is added for `Taylor1` and `TaylorN` expansions around a `Number` or `Vector`, respectively.

_**Obs:** The way "common" functions are expanded for arrays such as `taylor_expand(cos.[0.0,1.0])` for julia 0.6 output a warning about a method deprecation for arrays. They suggest to use now the **dot** operator instead, but this generates some problems with user defined functions._ 

