### PR TITLE
Declared new method for get_variables.

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -27,6 +27,7 @@ Taylor1([::Type{Float64}], [order::Int64=1])
 HomogeneousPolynomial{T<:Number}(::Type{T}, ::Int)
 TaylorN{T<:Number}(::Type{T}, nv::Int; [order::Int=get_order()])
 set_variables
+get_variables
 show_params_TaylorN
 get_coeff
 evaluate

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -211,6 +211,16 @@ variable name and the optional keyword argument `numvars`:
 set_variables("α", numvars=3)
 ```
 
+Alternatively to `set_variables`, [`get_variables`](@ref) can be used if one
+doesn't want to change internal dictionaries. `get_variables` returns a vector
+of independent variables  of a desired `order` (lesser than `get_order` so
+internals doesn't have to change) with the length and variable names defined
+by `set_variables` initially.
+
+```@repl userguide
+get_variables(order=2) #vector of independent variables of order 2
+```
+
 The function [`show_params_TaylorN`](@ref) displays the current values of the
 parameters, in an info block.
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -35,6 +35,7 @@ set_variable_names(names::Vector{T}) where {T<:AbstractString} =
     _params_TaylorN_.variable_names = names
 
 get_variables() = [TaylorN(i) for i in 1:get_numvars()]
+get_variables(order) = [TaylorN(i,order=order) for i in 1:get_numvars()]
 
 """
     set_variables([T::Type], names::String; [order=get_order(), numvars=-1])

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -34,6 +34,15 @@ get_variable_names() = _params_TaylorN_.variable_names
 set_variable_names(names::Vector{T}) where {T<:AbstractString} =
     _params_TaylorN_.variable_names = names
 
+"""
+    get_variables(;order=get_order())
+
+Return a `TaylorN` vector with each entry representing an
+independent variable. It takes the default `_params_TaylorN_` values
+if `set_variables` hasn't been changed with the exception that `order`
+can be explicitely established by the user without changing internal values
+for `num_vars` or `variable_names`.
+"""
 get_variables(;order::Integer=get_order()) = [TaylorN(i,order=order) for i in 1:get_numvars()]
 
 """

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -34,8 +34,7 @@ get_variable_names() = _params_TaylorN_.variable_names
 set_variable_names(names::Vector{T}) where {T<:AbstractString} =
     _params_TaylorN_.variable_names = names
 
-get_variables() = [TaylorN(i) for i in 1:get_numvars()]
-get_variables(order) = [TaylorN(i,order=order) for i in 1:get_numvars()]
+get_variables(;order::Integer=get_order()) = [TaylorN(i,order=order) for i in 1:get_numvars()]
 
 """
     set_variables([T::Type], names::String; [order=get_order(), numvars=-1])

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -27,6 +27,10 @@ end
     @test get_order() == 6
     @test get_numvars() == 2
 
+    @test get_variables()[1].order == get_order()
+    @test get_variables(order=2)[1].order == 2
+    @test get_variables(order=3)[1] == TaylorN(1,order=3)
+
     x, y = set_variables("x y", order=6)
     @test x.order == 6
     @test TaylorSeries.set_variable_names(["x","y"]) == ["x", "y"]


### PR DESCRIPTION
This just add a method `get_variables(order::Int)` where `order <  get_order()` so lower order `TaylorN`s can be taken without changing internals.
If `order >  get_order()`, an `AssertionError` is thrown. 
```julia
julia> using TaylorSeries

julia> get_variables()
2-element Array{TaylorSeries.TaylorN{Float64},1}:
  1.0 x₁ + 𝒪(‖x‖⁷)
  1.0 x₂ + 𝒪(‖x‖⁷)

julia> get_variables(2)
2-element Array{TaylorSeries.TaylorN{Float64},1}:
  1.0 x₁ + 𝒪(‖x‖³)
  1.0 x₂ + 𝒪(‖x‖³)

julia> get_variables(10)
ERROR: AssertionError: order ≤ get_order() && lencoef ≤ num_coeffs
```