### PR TITLE
RFC: Return n-th derivative of a Taylor1 as a Taylor1

### DIFF
--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -32,7 +32,7 @@ import Base: zero, one, zeros, ones, isinf, isnan, iszero,
 
 export Taylor1, TaylorN, HomogeneousPolynomial, AbstractSeries
 
-export getcoeff, derivative, derivativeval, integrate,
+export getcoeff, derivative, integrate,
     evaluate, evaluate!, inverse,
     show_params_TaylorN, show_monomials,
     get_order, get_numvars,

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -32,7 +32,7 @@ import Base: zero, one, zeros, ones, isinf, isnan, iszero,
 
 export Taylor1, TaylorN, HomogeneousPolynomial, AbstractSeries
 
-export getcoeff, derivative, integrate,
+export getcoeff, derivative, derivativeval, integrate,
     evaluate, evaluate!, inverse,
     show_params_TaylorN, show_monomials,
     get_order, get_numvars,

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -16,24 +16,41 @@ The last coefficient is set to zero.
 function derivative(a::Taylor1)
     res = zero(a)
     @inbounds for ord = 0:a.order-1
-        # res[ord] = (ord+1)*a[ord+1]
         derivative!(res, a, ord)
     end
     return res
 end
 
-function derivative!(res::Taylor1, a::Taylor1)
-    # res = zero(a)
+"""
+    derivative!(res, a) --> nothing
 
+In-place version of `derivative`. Compute the `Taylor1` polynomial of the
+differential of `a::Taylor1` and save it into `res`. The last coefficient is
+set to zero.
+"""
+function derivative!(res::Taylor1, a::Taylor1)
     @inbounds for ord = 0:a.order-1
-        # res[ord] = (ord+1)*a[ord+1]
         derivative!(res, a, ord)
     end
     res[a.order] = zero(a[0])
     nothing
-    # return res
 end
 
+doc"""
+    derivative!(p, a, k) --> nothing
+
+Update in-place the `k-th` expansion coefficient `p[k]` of `p = derivative(a)`
+for both `p` and `a` `Taylor1`.
+
+The coefficients are given by
+
+```math
+\begin{equation*}
+p_k = (k+1)a_{k+1}.
+\end{equation*}
+```
+
+"""
 derivative!(p::Taylor1, a::Taylor1, k::Int) = (p[k] = (k+1)*a[k+1])
 
 """

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -14,12 +14,27 @@ Return the `Taylor1` polynomial of the differential of `a::Taylor1`.
 The last coefficient is set to zero.
 """
 function derivative(a::Taylor1)
-    coeffs = zero(a.coeffs)
-    @inbounds for i = 1:a.order
-        coeffs[i] = i*a[i]
+    res = zero(a)
+    @inbounds for ord = 0:a.order-1
+        # res[ord] = (ord+1)*a[ord+1]
+        derivative!(res, a, ord)
     end
-    return Taylor1(coeffs, a.order)
+    return res
 end
+
+function derivative!(res::Taylor1, a::Taylor1)
+    # res = zero(a)
+
+    @inbounds for ord = 0:a.order-1
+        # res[ord] = (ord+1)*a[ord+1]
+        derivative!(res, a, ord)
+    end
+    res[a.order] = zero(a[0])
+    nothing
+    # return res
+end
+
+derivative!(p::Taylor1, a::Taylor1, k::Int) = (p[k] = (k+1)*a[k+1])
 
 """
     derivative(a, n)
@@ -31,10 +46,12 @@ function derivative(a::Taylor1{T}, n::Int) where {T <: Number}
     @assert a.order ≥ n ≥ 0
     if n==0
         return a
-    elseif n==1
-        return derivative(a)
     else
-        return derivative(derivative(a), n-1)
+        res = deepcopy(a)
+        for i in 1:n
+            derivative!(res, res)
+        end
+        return res
     end
 end
 

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -22,11 +22,28 @@ function derivative(a::Taylor1)
 end
 
 """
-    derivative(n, a)
+    derivative(a)
+
+Compute recursively the `Taylor1` polynomial of the n-th derivative of
+`a::Taylor1`.
+"""
+function derivative(n::Int, a::Taylor1{T}) where {T <: Number}
+    @assert a.order ≥ n ≥ 0
+    if n==0
+        return a
+    elseif n==1
+        return derivative(a)
+    else
+        return derivative(n-1, derivative(a))
+    end
+end
+
+"""
+    derivativeval(n, a)
 
 Return the value of the `n`-th derivative of the polynomial `a`.
 """
-function derivative(n::Int, a::Taylor1{T}) where {T<:Number}
+function derivativeval(n::Int, a::Taylor1{T}) where {T<:Number}
     @assert a.order ≥ n ≥ 0
     factorial( widen(n) ) * a[n] :: T
 end

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -22,28 +22,28 @@ function derivative(a::Taylor1)
 end
 
 """
-    derivative(a)
+    derivative(a, n)
 
 Compute recursively the `Taylor1` polynomial of the n-th derivative of
 `a::Taylor1`.
 """
-function derivative(n::Int, a::Taylor1{T}) where {T <: Number}
+function derivative(a::Taylor1{T}, n::Int) where {T <: Number}
     @assert a.order ≥ n ≥ 0
     if n==0
         return a
     elseif n==1
         return derivative(a)
     else
-        return derivative(n-1, derivative(a))
+        return derivative(derivative(a), n-1)
     end
 end
 
 """
-    derivativeval(n, a)
+    derivative(n, a)
 
 Return the value of the `n`-th derivative of the polynomial `a`.
 """
-function derivativeval(n::Int, a::Taylor1{T}) where {T<:Number}
+function derivative(n::Int, a::Taylor1{T}) where {T<:Number}
     @assert a.order ≥ n ≥ 0
     factorial( widen(n) ) * a[n] :: T
 end

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -250,7 +250,11 @@ end
     @test q[end-1:end] == pol[end-1:end]
 
 
-    @test_throws DomainError yT^(-2)
+    if VERSION < v"0.7.0-DEV"
+        @test_throws DomainError yT^(-2)
+    else
+        @test_throws AssertionError yT^(-2)
+    end
     @test_throws DomainError yT^(-2.0)
     @test (1+xT)^(3//2) == ((1+xT)^0.5)^3
     @test real(xH) == xH

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -259,4 +259,8 @@ end
     @test p1N ≈ p1N
     @test p1N ≈ q1N
 
+    Pv = [rndTN(get_order(), 3), rndTN(get_order(), 3)]
+    Qv = convert.(Taylor1{TaylorN{Float64}}, Pv)
+
+    @test jacobian(Pv) == jacobian(Qv)
 end

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -302,9 +302,12 @@ end
     @test evaluate(v, complex(0.0,0.2)) ==
         [complex(0.0,sinh(0.2)),complex(cos(0.2),sin(-0.2))]
 
-    fifth_exp_deriv = Taylor1(convert(Vector{Float64},exp(ta(1.0))[0:10]))
-    @test derivative(5, exp(ta(1.0))) ≈ exp(1.0) atol=eps() rtol=0.0
-    # @test derivative(3, exp(ta(1.0pi))) == exp(1.0pi)
+    expected_result_approx = Taylor1(convert(Vector{Float64},exp(ta(1.0))[0:10]))
+    @test derivative(5, exp(ta(1.0))) ≈ expected_result_approx atol=eps() rtol=0.0
+    expected_result_approx = Taylor1(convert(Vector{Float64},exp(ta(1.0pi))[0:12]),15)
+    @test derivative(3, exp(ta(1.0pi))) ≈ expected_result_approx atol=eps(16.0) rtol=0.0
+    expected_result_approx = Taylor1(convert(Vector{Float64},exp(ta(1.0pi))[0:5]),15)
+    @test derivative(10, exp(ta(1.0pi))) ≈ expected_result_approx atol=eps(64.0) rtol=0.0
     # @test isapprox(derivative(10, exp(ta(1.0pi))) , exp(1.0pi) )
 
     @test derivative(5, exp(ta(1.0)))() == exp(1.0)

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -332,7 +332,11 @@ end
     @test_throws ArgumentError 1/t
     @test_throws ArgumentError zt/zt
     @test_throws ArgumentError t^1.5
-    @test_throws DomainError t^(-2)
+    if VERSION < v"0.7.0-DEV"
+        @test_throws DomainError t^(-2)
+    else
+        @test_throws ArgumentError t^(-2)
+    end
     @test_throws ArgumentError sqrt(t)
     @test_throws ArgumentError log(t)
     @test_throws ArgumentError cos(t)/sin(t)

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -301,9 +301,20 @@ end
     @test evaluate(v) == vv
     @test evaluate(v, complex(0.0,0.2)) ==
         [complex(0.0,sinh(0.2)),complex(cos(0.2),sin(-0.2))]
-    @test derivative(5, exp(ta(1.0))) == exp(1.0)
-    @test derivative(3, exp(ta(1.0pi))) == exp(1.0pi)
-    @test isapprox(derivative(10, exp(ta(1.0pi))) , exp(1.0pi) )
+
+    fifth_exp_deriv = Taylor1(convert(Vector{Float64},exp(ta(1.0))[0:10]))
+    @test derivative(5, exp(ta(1.0))) ≈ exp(1.0) atol=eps() rtol=0.0
+    # @test derivative(3, exp(ta(1.0pi))) == exp(1.0pi)
+    # @test isapprox(derivative(10, exp(ta(1.0pi))) , exp(1.0pi) )
+
+    @test derivative(5, exp(ta(1.0)))() == exp(1.0)
+    @test derivative(3, exp(ta(1.0pi)))() == exp(1.0pi)
+    @test isapprox(derivative(10, exp(ta(1.0pi)))() , exp(1.0pi) )
+
+    @test derivativeval(5, exp(ta(1.0))) == exp(1.0)
+    @test derivativeval(3, exp(ta(1.0pi))) == exp(1.0pi)
+    @test isapprox(derivativeval(10, exp(ta(1.0pi))) , exp(1.0pi) )
+
     @test integrate(derivative(exp(t)),1) == exp(t)
     @test integrate(cos(t)) == sin(t)
 

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -302,13 +302,15 @@ end
     @test evaluate(v, complex(0.0,0.2)) ==
         [complex(0.0,sinh(0.2)),complex(cos(0.2),sin(-0.2))]
 
+    @test derivative(exp(ta(1.0)), 0) == exp(ta(1.0))
     expected_result_approx = Taylor1(convert(Vector{Float64},exp(ta(1.0))[0:10]))
     @test derivative(exp(ta(1.0)), 5) ≈ expected_result_approx atol=eps() rtol=0.0
     expected_result_approx = Taylor1(convert(Vector{Float64},exp(ta(1.0pi))[0:12]),15)
     @test derivative(exp(ta(1.0pi)), 3) ≈ expected_result_approx atol=eps(16.0) rtol=0.0
     expected_result_approx = Taylor1(convert(Vector{Float64},exp(ta(1.0pi))[0:5]),15)
     @test derivative(exp(ta(1.0pi)), 10) ≈ expected_result_approx atol=eps(64.0) rtol=0.0
-    # @test isapprox(derivative(10, exp(ta(1.0pi))) , exp(1.0pi) )
+
+
 
     @test derivative(exp(ta(1.0)), 5)() == exp(1.0)
     @test derivative(exp(ta(1.0pi)), 3)() == exp(1.0pi)

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -303,20 +303,20 @@ end
         [complex(0.0,sinh(0.2)),complex(cos(0.2),sin(-0.2))]
 
     expected_result_approx = Taylor1(convert(Vector{Float64},exp(ta(1.0))[0:10]))
-    @test derivative(5, exp(ta(1.0))) ≈ expected_result_approx atol=eps() rtol=0.0
+    @test derivative(exp(ta(1.0)), 5) ≈ expected_result_approx atol=eps() rtol=0.0
     expected_result_approx = Taylor1(convert(Vector{Float64},exp(ta(1.0pi))[0:12]),15)
-    @test derivative(3, exp(ta(1.0pi))) ≈ expected_result_approx atol=eps(16.0) rtol=0.0
+    @test derivative(exp(ta(1.0pi)), 3) ≈ expected_result_approx atol=eps(16.0) rtol=0.0
     expected_result_approx = Taylor1(convert(Vector{Float64},exp(ta(1.0pi))[0:5]),15)
-    @test derivative(10, exp(ta(1.0pi))) ≈ expected_result_approx atol=eps(64.0) rtol=0.0
+    @test derivative(exp(ta(1.0pi)), 10) ≈ expected_result_approx atol=eps(64.0) rtol=0.0
     # @test isapprox(derivative(10, exp(ta(1.0pi))) , exp(1.0pi) )
 
-    @test derivative(5, exp(ta(1.0)))() == exp(1.0)
-    @test derivative(3, exp(ta(1.0pi)))() == exp(1.0pi)
-    @test isapprox(derivative(10, exp(ta(1.0pi)))() , exp(1.0pi) )
+    @test derivative(exp(ta(1.0)), 5)() == exp(1.0)
+    @test derivative(exp(ta(1.0pi)), 3)() == exp(1.0pi)
+    @test isapprox(derivative(exp(ta(1.0pi)), 10)() , exp(1.0pi) )
 
-    @test derivativeval(5, exp(ta(1.0))) == exp(1.0)
-    @test derivativeval(3, exp(ta(1.0pi))) == exp(1.0pi)
-    @test isapprox(derivativeval(10, exp(ta(1.0pi))) , exp(1.0pi) )
+    @test derivative(5, exp(ta(1.0))) == exp(1.0)
+    @test derivative(3, exp(ta(1.0pi))) == exp(1.0pi)
+    @test isapprox(derivative(10, exp(ta(1.0pi))) , exp(1.0pi) )
 
     @test integrate(derivative(exp(t)),1) == exp(t)
     @test integrate(cos(t)) == sin(t)


### PR DESCRIPTION
Current implementation returns the derivative of a `Taylor1` as a `Taylor1`, but higher-order derivatives of a `Taylor1` are returned as single values. This PR is intended to instead return higher-order derivatives of a `Taylor1` polynomial as a `Taylor1` polynomial. In order to do this, this PR adds a new method to `derivative(n::Int, a::Taylor1)` and renames the existing method for the value of the n-th derivative of a Taylor1 polynomial as `derivativeval` (name suggestions are more than welcome 😛!). This was done in order to get the whole n-th derivative polynomial when it's needed, but the existing method for the value of the n-th derivative is faster when only the numerical value is needed, so it was kept for performance reasons.