### PR TITLE
Avoid irrelevant checks in getindex and setindex!

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -57,10 +57,8 @@ generate_tables
 generate_index_vectors
 in_base
 make_inverse_dict
-order_posTb
 resize_coeffs1!
 resize_coeffsHP!
-zero_korder
 constant_term
 mul!
 mul!(c::HomogeneousPolynomial, a::HomogeneousPolynomial, b::HomogeneousPolynomial)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -122,7 +122,6 @@ for (f, fc) in ((:+, :(add!)), (:-, :(subst!)))
                 return nothing
             end
             function ($fc)(v::$T, a::NumberNotSeries, k::Int)
-                ### OJO
                 @inbounds v[k] = k==0 ? ($f)(zero(v[0]),a) : zero(v[k])
                 return nothing
             end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -122,6 +122,7 @@ for (f, fc) in ((:+, :(add!)), (:-, :(subst!)))
                 return nothing
             end
             function ($fc)(v::$T, a::NumberNotSeries, k::Int)
+                ### OJO
                 @inbounds v[k] = k==0 ? ($f)(zero(v[0]),a) : zero(v[k])
                 return nothing
             end
@@ -211,7 +212,7 @@ for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
         *(a::$T, b::Bool) = b * a
 
         function *(a::T, b::$T) where {T<:NumberNotSeries}
-            @inbounds aux = a * b[1]
+            @inbounds aux = a * b.coeffs[1]
             v = Array{typeof(aux)}(length(b.coeffs))
             @__dot__ v = a * b.coeffs
             return $T(v, b.order)
@@ -286,7 +287,7 @@ end
 for T in (:Taylor1, :TaylorN)
     @eval @inline function mul!(c::$T, a::$T, b::$T, k::Int)
 
-        # c[k+1] = zero( a[k+1] )
+        # c[k] = zero( a[k] )
         @inbounds for i = 0:k
             if $T == Taylor1
                 c[k] += a[i] * b[k-i]
@@ -311,7 +312,7 @@ end
 doc"""
     mul!(c, a, b, k::Int) --> nothing
 
-Update the `k`-th expansion coefficient `c[k+1]` of `c = a * b`,
+Update the `k`-th expansion coefficient `c[k]` of `c = a * b`,
 where all `c`, `a`, and `b` are either `Taylor1` or `TaylorN`.
 
 The coefficients are given by
@@ -467,7 +468,7 @@ end
 doc"""
     div!(c, a, b, k::Int, ordfact::Int=0)
 
-Compute the `k-th` expansion coefficient `c[k+1]` of `c = a / b`,
+Compute the `k-th` expansion coefficient `c[k]` of `c = a / b`,
 where all `c`, `a` and `b` are either `Taylor1` or `TaylorN`.
 
 The coefficients are given by

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -74,27 +74,27 @@ Return the coefficient of order `n::Int` of a `a::Taylor1` polynomial.
 getcoeff(a::Taylor1, n::Int) = (@assert 0 ≤ n ≤ a.order; return a[n])
 
 function getindex(a::Taylor1, n::Int)
-    @assert 0 ≤ n ≤ length(a.coeffs)
-    nn = n == length(a.coeffs) ? n : n+1
-    return a.coeffs[nn]
+    # @assert 0 ≤ n ≤ length(a.coeffs)
+    # nn = n == length(a.coeffs) ? n : n+1
+    return a.coeffs[n+1]
 end
 function getindex(a::Taylor1, u::UnitRange)
-    u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
-    view(a.coeffs, (1+u.start):u_stop )
+    # u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
+    view(a.coeffs, u+1 )
 end
 getindex(a::Taylor1, c::Colon) = view(a.coeffs, c)
 
 function setindex!(a::Taylor1{T}, x::T, n::Int) where {T<:Number}
-    @assert 0 ≤ n ≤ a.order
+    # @assert 0 ≤ n ≤ a.order
     a.coeffs[n+1] = x
 end
 function setindex!(a::Taylor1{T}, x::T, u::UnitRange) where {T<:Number}
-    u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
-    a.coeffs[(u.start+1):u_stop] = x
+    # u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
+    a.coeffs[u+1] = x
 end
 function setindex!(a::Taylor1{T}, x::Array{T,1}, u::UnitRange) where {T<:Number}
-    u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
-    a.coeffs[(u.start+1):u_stop] .= x
+    # u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
+    a.coeffs[u+1] .= x
 end
 setindex!(a::Taylor1{T}, x::T, c::Colon) where {T<:Number} = a.coeffs[c] = x
 setindex!(a::Taylor1{T}, x::Array{T,1}, c::Colon) where {T<:Number} = a.coeffs[c] = x
@@ -143,12 +143,12 @@ end
 
 function getindex(a::TaylorN, n::Int)
     # @assert 0 ≤ n ≤ length(a.coeffs)
-    nn = n == length(a.coeffs) ? n : n+1
-    return a.coeffs[nn]
+    # nn = n == length(a.coeffs) ? n : n+1
+    return a.coeffs[n+1]
 end
 function getindex(a::TaylorN, u::UnitRange)
-    u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
-    view(a.coeffs, (1+u.start):u_stop )
+    # u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
+    view(a.coeffs, u+1 )
 end
 getindex(a::TaylorN, c::Colon) = view(a.coeffs, c)
 

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -73,29 +73,14 @@ Return the coefficient of order `n::Int` of a `a::Taylor1` polynomial.
 """
 getcoeff(a::Taylor1, n::Int) = (@assert 0 ≤ n ≤ a.order; return a[n])
 
-function getindex(a::Taylor1, n::Int)
-    # @assert 0 ≤ n ≤ length(a.coeffs)
-    # nn = n == length(a.coeffs) ? n : n+1
-    return a.coeffs[n+1]
-end
-function getindex(a::Taylor1, u::UnitRange)
-    # u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
-    view(a.coeffs, u+1 )
-end
+getindex(a::Taylor1, n::Int) = a.coeffs[n+1]
+getindex(a::Taylor1, u::UnitRange) = view(a.coeffs, u+1 )
 getindex(a::Taylor1, c::Colon) = view(a.coeffs, c)
 
-function setindex!(a::Taylor1{T}, x::T, n::Int) where {T<:Number}
-    # @assert 0 ≤ n ≤ a.order
-    a.coeffs[n+1] = x
-end
-function setindex!(a::Taylor1{T}, x::T, u::UnitRange) where {T<:Number}
-    # u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
-    a.coeffs[u+1] = x
-end
-function setindex!(a::Taylor1{T}, x::Array{T,1}, u::UnitRange) where {T<:Number}
-    # u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
+setindex!(a::Taylor1{T}, x::T, n::Int) where {T<:Number} = a.coeffs[n+1] = x
+setindex!(a::Taylor1{T}, x::T, u::UnitRange) where {T<:Number} = a.coeffs[u+1] = x
+setindex!(a::Taylor1{T}, x::Array{T,1}, u::UnitRange) where {T<:Number} =
     a.coeffs[u+1] .= x
-end
 setindex!(a::Taylor1{T}, x::T, c::Colon) where {T<:Number} = a.coeffs[c] = x
 setindex!(a::Taylor1{T}, x::Array{T,1}, c::Colon) where {T<:Number} = a.coeffs[c] = x
 
@@ -141,15 +126,8 @@ function getcoeff(a::TaylorN, v::Array{Int,1})
     getcoeff(a[order], v)
 end
 
-function getindex(a::TaylorN, n::Int)
-    # @assert 0 ≤ n ≤ length(a.coeffs)
-    # nn = n == length(a.coeffs) ? n : n+1
-    return a.coeffs[n+1]
-end
-function getindex(a::TaylorN, u::UnitRange)
-    # u_stop = u.stop == length(a.coeffs) ? u.stop : u.stop+1
-    view(a.coeffs, u+1 )
-end
+getindex(a::TaylorN, n::Int) = a.coeffs[n+1]
+getindex(a::TaylorN, u::UnitRange) = view(a.coeffs, u+1 )
 getindex(a::TaylorN, c::Colon) = view(a.coeffs, c)
 
 function setindex!(a::TaylorN{T}, x::HomogeneousPolynomial{T}, n::Int) where
@@ -227,38 +205,8 @@ function fixorder(a::HomogeneousPolynomial, b::HomogeneousPolynomial)
 end
 
 
-"""
-    zero_korder(a)
-
-For `a::Taylor1` returns `zero(a[1])` while for `a::TaylorN` returns
-a zero of a k-th order `HomogeneousPolynomial` of proper type.
-"""
-zero_korder(a::Taylor1, ::Int) = zero(a[0])
-
-zero_korder(a::TaylorN, k::Int) = HomogeneousPolynomial(zero(constant_term(a)), k)
-
-
 # Finds the first non zero entry; extended to Taylor1
 Base.findfirst(a::Taylor1{T}) where {T<:Number} = findfirst(a.coeffs)-1
-
-
-"""
-    order_posTb(order, nv, ord)
-
-Return a vector with the positions, in a `HomogeneousPolynomial` of
-order `order`, where the variable `nv` has order `ord`.
-"""
-function order_posTb(order::Int, nv::Int, ord::Int)
-    @assert order ≤ get_order()
-    @inbounds indTb = coeff_table[order+1]
-    @inbounds num_coeffs = size_table[order+1]
-    posV = Int[]
-    for pos = 1:num_coeffs
-        @inbounds indTb[pos][nv] != ord && continue
-        push!(posV, pos)
-    end
-    posV
-end
 
 
 """

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -306,7 +306,7 @@ end
     TaylorSeries.subst!(xx, 5.0, 0)
     @test xx[0] == HomogeneousPolynomial([-5.0])
     TaylorSeries.subst!(xx, -5.0, 1)
-    @test xx[1] == zero(xx[2])
+    @test xx[1] == zero(xx[end])
     TaylorSeries.div!(xx, 1.0+xT, 1.0+xT, 0)
     @test xx[0] == 1.0
     TaylorSeries.pow!(xx, 1.0+xT, 1.5, 0)


### PR DESCRIPTION
This PR erases some `@assert`s and other bound-checking instructions which I introduced while implementing #135. They induce a general slowdown and are not necessary.