### PR TITLE
Extend evaluate on AbstractArray, instead of Array

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -264,6 +264,10 @@ function evaluate(a::TaylorN{T}, vals::NTuple{N,S}) where
     return sum( sort!(suma, by=abs2) )
 end
 
+# This should allow to evaluate IntervalBoxes appropriately
+evaluate(a::TaylorN{T}, vals::AbstractArray) where
+    {T<:TaylorSeries.NumberNotSeries} = evaluate(a, vals...,)
+
 evaluate(a::TaylorN{T}, vals::Array{S,1}) where
     {T<:Number, S<:NumberNotSeriesN} = evaluate(a, (vals...,))
 

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -264,8 +264,7 @@ function evaluate(a::TaylorN{T}, vals::NTuple{N,S}) where
     return sum( sort!(suma, by=abs2) )
 end
 
-evaluate(a::TaylorN{T}, vals::AbstractArray{S,1}) where
-    {T<:Number, S<:NumberNotSeries} = evaluate(a, (vals...,))
+evaluate(a::TaylorN, vals) = evaluate(a, (vals...,))
 
 evaluate(a::TaylorN, v, vals...) = evaluate(a, (v, vals...,))
 

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -264,12 +264,8 @@ function evaluate(a::TaylorN{T}, vals::NTuple{N,S}) where
     return sum( sort!(suma, by=abs2) )
 end
 
-# This should allow to evaluate IntervalBoxes appropriately
-evaluate(a::TaylorN{T}, vals::AbstractArray) where
-    {T<:TaylorSeries.NumberNotSeries} = evaluate(a, vals...,)
-
-evaluate(a::TaylorN{T}, vals::Array{S,1}) where
-    {T<:Number, S<:NumberNotSeriesN} = evaluate(a, (vals...,))
+evaluate(a::TaylorN{T}, vals::AbstractArray{S,1}) where
+    {T<:Number, S<:NumberNotSeries} = evaluate(a, (vals...,))
 
 evaluate(a::TaylorN, v, vals...) = evaluate(a, (v, vals...,))
 

--- a/test/intervals.jl
+++ b/test/intervals.jl
@@ -37,5 +37,7 @@ end
     for ind in eachindex((p5(x,-b)).coeffs)
         @test all(((p5(x,-b)).coeffs[ind]).coeffs .⊆ (((x-b)^5).coeffs[ind]).coeffs)
     end
+    @test evaluate(p4(x,-b), IntervalBox(a,b)) == p4(a, b)
+    @test (p5(x,-b))(IntervalBox(a,b)) == p5(a, b)
 
 end


### PR DESCRIPTION
This allows for evaluations using `IntervalBoxes`.