### PR TITLE
Allow using Base.show_default instead of custom show

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -48,6 +48,7 @@ norm
 isapprox
 isfinite
 displayBigO
+use_show_default
 ```
 
 ## Internals

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -57,6 +57,17 @@ displayBigO(true) # turn it on
 t
 ```
 
+Similarly, it is possible to control if the format of the
+displayed series through the function [`use_show_default`](@ref);
+`use_show_default(true)` uses the `Base.show_default`, while
+`use_show_default(false)` uses the custom display form (default).
+```@repl userguide
+use_show_default(true) # use Base.show method
+t
+use_show_default(false) # use custom `show`
+t
+```
+
 The definition of `shift_taylor(a)` uses the method
 [`Taylor1([::Type{Float64}], [order::Int64=1])`](@ref), which is a
 shortcut to define the independent variable of a Taylor expansion,

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -48,7 +48,7 @@ export Taylor1, TaylorN, HomogeneousPolynomial, AbstractSeries
 
 export getcoeff, derivative, integrate,
     evaluate, evaluate!, inverse,
-    show_params_TaylorN, show_monomials, displayBigO,
+    show_params_TaylorN, show_monomials, displayBigO, use_show_default,
     get_order, get_numvars,
     set_variables, get_variables,
     get_variable_names, get_variable_symbols,

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -171,6 +171,7 @@ end
 
 # Control the display of the big 𝒪 notation
 const bigOnotation = Bool[true]
+const _show_default = [false]
 
 """
     displayBigO(d::Bool) --> nothing
@@ -180,3 +181,12 @@ of `Taylor1` and `TaylorN` polynomials. The initial value is
 `true`.
 """
 displayBigO(d::Bool) = (bigOnotation[end] = d; d)
+
+"""
+    use_Base_show(d::Bool) --> nothing
+
+Use `Base.show_default` method (default `show` method
+in Base), or a custom display. The initial value is
+`false`, so customized fisplay is used.
+"""
+use_show_default(d::Bool) = (_show_default[end] = d; d)

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -252,7 +252,7 @@ end
 # show
 function show(io::IO, a::Union{Taylor1, HomogeneousPolynomial, TaylorN})
     if _show_default[end]
-        return Base.show_default(io, a)
+        return Base.show_default(IOContext(io, :compact => false), a)
     else
         return print(io, pretty_print(a))
     end

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -251,5 +251,9 @@ end
 
 # show
 function show(io::IO, a::Union{Taylor1, HomogeneousPolynomial, TaylorN})
-    print(io, pretty_print(a))
+    if _show_default[end]
+        return Base.show_default(io, a)
+    else
+        return print(io, pretty_print(a))
+    end
 end

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -19,10 +19,9 @@ function superscriptify(n::Int)
 end
 
 
-function pretty_print(a::Taylor1{T}) where {T<:Number}
+function pretty_print(a::Taylor1{T}) where {T<:NumberNotSeries}
     z = zero(a[0])
     space = string(" ")
-    # bigO = string("+ 𝒪(t", superscriptify(a.order+1), ")")
     bigO = bigOnotation[end] ?
         string("+ 𝒪(t", superscriptify(a.order+1), ")") :
         string("")
@@ -42,39 +41,12 @@ function pretty_print(a::Taylor1{T}) where {T<:Number}
     strout
 end
 
-function pretty_print(a::Taylor1{HomogeneousPolynomial{T}}) where {T<:Number}
+function pretty_print(a::Taylor1{T} where {T <: AbstractSeries{S}}) where {S<:Number}
     z = zero(a[0])
     space = string(" ")
-    # bigO = string("+ 𝒪(t", superscriptify(a.order+1), ")")
     bigO = bigOnotation[end] ?
         string("+ 𝒪(t", superscriptify(a.order+1), ")") :
         string("")
-    iszero(a) && return string(space, z, space, bigO)
-    strout::String = space
-    ifirst = true
-    for i in eachindex(a.coeffs)
-        monom::String = i==1 ? string("") : i==2 ? string(" t") :
-            string(" t", superscriptify(i-1))
-        @inbounds c = a[i-1]
-        c == z && continue
-        cadena = numbr2str(c, ifirst)
-        ccad::String = i==1 ? cadena : ifirst ? string("(", cadena, ")") :
-            string(cadena[1:2], "(", cadena[3:end], ")")
-        strout = string(strout, ccad, monom, space)
-        ifirst = false
-    end
-    strout = strout * bigO
-    strout
-end
-
-function pretty_print(a::Taylor1{TaylorN{T}}) where {T<:Number}
-    z = zero(a[0])
-    space = string(" ")
-    # bigO = string("+ 𝒪(t", superscriptify(a.order+1), ")")
-    bigO = bigOnotation[end] ?
-        string("+ 𝒪(t", superscriptify(a.order+1), ")") :
-        string("")
-    iszero(a) && return string(space, z, space, bigO)
     iszero(a) && return string(space, z, space, bigO)
     strout::String = space
     ifirst = true
@@ -104,13 +76,11 @@ end
 function pretty_print(a::TaylorN{T}) where {T<:Number}
     z = zero(a[0])
     space = string("")
-    # bigO::String  = string(" + 𝒪(‖x‖", superscriptify(a.order+1), ")")
     bigO::String = bigOnotation[end] ?
         string(" + 𝒪(‖x‖", superscriptify(a.order+1), ")") :
         string("")
     iszero(a) && return string(space, z, space, bigO)
-    iszero(a) && return string(space, z, bigO)
-    strout::String = space#string("")
+    strout::String = space
     ifirst = true
     for ord in eachindex(a.coeffs)
         pol = a[ord-1]

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -522,21 +522,31 @@ end
             "TaylorN{Float64}(HomogeneousPolynomial{Float64}" *
             "[HomogeneousPolynomial{Float64}([0.0], 0), " *
             "HomogeneousPolynomial{Float64}([0.0, 1.4142135623730951], 1)], 1)"
+        @test string([aa, aa]) ==
+            "HomogeneousPolynomial{Float64}[HomogeneousPolynomial{Float64}" *
+            "([1.4142135623730951, 0.0], 1), HomogeneousPolynomial{Float64}" *
+            "([1.4142135623730951, 0.0], 1)]"
+        @test string([ab, ab]) == "TaylorN{Float64}[TaylorN{Float64}" *
+            "(HomogeneousPolynomial{Float64}[HomogeneousPolynomial{Float64}([0.0], 0), " *
+            "HomogeneousPolynomial{Float64}([0.0, 1.4142135623730951], 1)], 1), " *
+            "TaylorN{Float64}(HomogeneousPolynomial{Float64}[HomogeneousPolynomial{Float64}" *
+            "([0.0], 0), HomogeneousPolynomial{Float64}([0.0, 1.4142135623730951], 1)], 1)]"
     end
     use_show_default(false)
     @test string(aa) == " 1.4142135623730951 x₁"
     @test string(ab) == " 1.4142135623730951 x₂ + 𝒪(‖x‖²)"
-    @test string([aa, aa]) == "TaylorSeries.HomogeneousPolynomial{Float64}" *
-        "[ 1.4142135623730951 x₁,  1.4142135623730951 x₁]"
-    @test string([ab, ab]) == "TaylorSeries.TaylorN{Float64}" *
-        "[ 1.4142135623730951 x₂ + 𝒪(‖x‖²),  1.4142135623730951 x₂ + 𝒪(‖x‖²)]"
     displayBigO(false)
     @test string(-xH) == " - 1 x₁"
     @test string(xT^2) == " 1 x₁²"
     @test string(1im*yT) == " ( 1 im ) x₂"
     @test string(xT-im*yT) == "  ( 1 ) x₁ - ( 1 im ) x₂"
-    @test string([ab, ab]) == "TaylorSeries.TaylorN{Float64}" *
-        "[ 1.4142135623730951 x₂,  1.4142135623730951 x₂]"
+    if VERSION < v"0.7.0-DEV"
+        @test string([ab, ab]) == "TaylorSeries.TaylorN{Float64}" *
+            "[ 1.4142135623730951 x₂,  1.4142135623730951 x₂]"
+    else
+        @test string([ab, ab]) ==
+            "TaylorN{Float64}[ 1.4142135623730951 x₂,  1.4142135623730951 x₂]"
+    end
     displayBigO(true)
     @test string(-xH) == " - 1 x₁"
     @test string(xT^2) == " 1 x₁² + 𝒪(‖x‖¹⁸)"

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -501,6 +501,15 @@ end
     hessian!(hes, g1(xT+1,yT-1)-g2(xT+1,yT-1))
     @test hes1 == hes
 
+    use_show_default(true)
+    @test string(xH) == "TaylorSeries.HomogeneousPolynomial{Int64}([1, 0], 1)"
+    @test string(TaylorN(2, order=1)) ==
+    "TaylorSeries.TaylorN{Float64}(TaylorSeries.HomogeneousPolynomial{Float64}" *
+    "[TaylorSeries.HomogeneousPolynomial{Float64}([0.0], 0), " *
+    "TaylorSeries.HomogeneousPolynomial{Float64}([0.0, 1.0], 1)], 1)"
+    use_show_default(false)
+    @test string(xH) == " 1 x₁"
+
     displayBigO(false)
     @test string(-xH) == " - 1 x₁"
     @test string(xT^2) == " 1 x₁²"

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -502,19 +502,41 @@ end
     @test hes1 == hes
 
     use_show_default(true)
-    @test string(xH) == "TaylorSeries.HomogeneousPolynomial{Int64}([1, 0], 1)"
-    @test string(TaylorN(2, order=1)) ==
-    "TaylorSeries.TaylorN{Float64}(TaylorSeries.HomogeneousPolynomial{Float64}" *
-    "[TaylorSeries.HomogeneousPolynomial{Float64}([0.0], 0), " *
-    "TaylorSeries.HomogeneousPolynomial{Float64}([0.0, 1.0], 1)], 1)"
+    aa = sqrt(2) * xH
+    ab = sqrt(2) * TaylorN(2, order=1)
+    if VERSION < v"0.7.0-DEV"
+        @test string(aa) ==
+            "TaylorSeries.HomogeneousPolynomial{Float64}([1.4142135623730951, 0.0], 1)"
+        @test string([aa]) == "TaylorSeries.HomogeneousPolynomial{Float64}" *
+            "[TaylorSeries.HomogeneousPolynomial{Float64}([1.4142135623730951, 0.0], 1)]"
+        @test string(ab) == "TaylorSeries.TaylorN{Float64}(TaylorSeries.HomogeneousPolynomial{Float64}" *
+            "[TaylorSeries.HomogeneousPolynomial{Float64}([0.0], 0), " *
+            "TaylorSeries.HomogeneousPolynomial{Float64}([0.0, 1.4142135623730951], 1)], 1)"
+        @test string([ab]) == "TaylorSeries.TaylorN{Float64}[TaylorSeries.TaylorN{Float64}" *
+            "(TaylorSeries.HomogeneousPolynomial{Float64}[TaylorSeries.HomogeneousPolynomial{Float64}([0.0], 0), " *
+            "TaylorSeries.HomogeneousPolynomial{Float64}([0.0, 1.4142135623730951], 1)], 1)]"
+    else
+        @test string(aa) ==
+            "HomogeneousPolynomial{Float64}([1.4142135623730951, 0.0], 1)"
+        @test string(ab) ==
+            "TaylorN{Float64}(HomogeneousPolynomial{Float64}" *
+            "[HomogeneousPolynomial{Float64}([0.0], 0), " *
+            "HomogeneousPolynomial{Float64}([0.0, 1.4142135623730951], 1)], 1)"
+    end
     use_show_default(false)
-    @test string(xH) == " 1 x₁"
-
+    @test string(aa) == " 1.4142135623730951 x₁"
+    @test string(ab) == " 1.4142135623730951 x₂ + 𝒪(‖x‖²)"
+    @test string([aa, aa]) == "TaylorSeries.HomogeneousPolynomial{Float64}" *
+        "[ 1.4142135623730951 x₁,  1.4142135623730951 x₁]"
+    @test string([ab, ab]) == "TaylorSeries.TaylorN{Float64}" *
+        "[ 1.4142135623730951 x₂ + 𝒪(‖x‖²),  1.4142135623730951 x₂ + 𝒪(‖x‖²)]"
     displayBigO(false)
     @test string(-xH) == " - 1 x₁"
     @test string(xT^2) == " 1 x₁²"
     @test string(1im*yT) == " ( 1 im ) x₂"
     @test string(xT-im*yT) == "  ( 1 ) x₁ - ( 1 im ) x₂"
+    @test string([ab, ab]) == "TaylorSeries.TaylorN{Float64}" *
+        "[ 1.4142135623730951 x₂,  1.4142135623730951 x₂]"
     displayBigO(true)
     @test string(-xH) == " - 1 x₁"
     @test string(xT^2) == " 1 x₁² + 𝒪(‖x‖¹⁸)"

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -399,6 +399,10 @@ end
     @test_throws ArgumentError inverse(exp(t))
     @test_throws ArgumentError abs(t)
 
+    use_show_default(true)
+    @test string(2+Taylor1(2)) == "TaylorSeries.Taylor1{Float64}([2.0, 1.0, 0.0], 2)"
+    use_show_default(false)
+    @test string(2+Taylor1(2)) == " 2.0 + 1.0 t + 𝒪(t³)"
     displayBigO(false)
     @test string(ta(-3)) == " - 3 + 1 t "
     @test string(ta(0)^3-3) == " - 3 + 1 t³ "

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -409,8 +409,8 @@ end
     else
         @test string(aa) == "Taylor1{Float64}([1.4142135623730951, 1.0, 0.0], 2)"
         @test string([aa, aa]) ==
-            "TaylorSeries.Taylor1{Float64}[TaylorSeries.Taylor1{Float64}([1.4142135623730951, 1.0, 0.0], 2), " *
-            "TaylorSeries.Taylor1{Float64}([1.4142135623730951, 1.0, 0.0], 2)]"
+            "Taylor1{Float64}[Taylor1{Float64}([1.4142135623730951, 1.0, 0.0], 2), " *
+            "Taylor1{Float64}([1.4142135623730951, 1.0, 0.0], 2)]"
     end
     use_show_default(false)
     @test string(aa) == " 1.4142135623730951 + 1.0 t + 𝒪(t³)"

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -400,9 +400,20 @@ end
     @test_throws ArgumentError abs(t)
 
     use_show_default(true)
-    @test string(2+Taylor1(2)) == "TaylorSeries.Taylor1{Float64}([2.0, 1.0, 0.0], 2)"
+    aa = sqrt(2)+Taylor1(2)
+    if VERSION < v"0.7.0-DEV"
+        @test string(aa) == "TaylorSeries.Taylor1{Float64}([1.4142135623730951, 1.0, 0.0], 2)"
+        @test string([aa, aa]) ==
+            "TaylorSeries.Taylor1{Float64}[TaylorSeries.Taylor1{Float64}([1.4142135623730951, 1.0, 0.0], 2), " *
+            "TaylorSeries.Taylor1{Float64}([1.4142135623730951, 1.0, 0.0], 2)]"
+    else
+        @test string(aa) == "Taylor1{Float64}([1.4142135623730951, 1.0, 0.0], 2)"
+        @test string([aa, aa]) ==
+            "TaylorSeries.Taylor1{Float64}[TaylorSeries.Taylor1{Float64}([1.4142135623730951, 1.0, 0.0], 2), " *
+            "TaylorSeries.Taylor1{Float64}([1.4142135623730951, 1.0, 0.0], 2)]"
+    end
     use_show_default(false)
-    @test string(2+Taylor1(2)) == " 2.0 + 1.0 t + 𝒪(t³)"
+    @test string(aa) == " 1.4142135623730951 + 1.0 t + 𝒪(t³)"
     displayBigO(false)
     @test string(ta(-3)) == " - 3 + 1 t "
     @test string(ta(0)^3-3) == " - 3 + 1 t³ "


### PR DESCRIPTION
This allows to use the default function in Base for `show` instead of the customized one. This is important, e.g., when saving series to a file to load them later.