### PR TITLE
Skip interval tests in Julia0.7

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,5 +13,8 @@ testfiles = (
     )
 
 for file in testfiles
+    # Tests in 0.7 pass when current IntervalArithmetics master
+    # is used, i.e., IntervalArithmetic 0.14.0, not yet released
+    file == "intervals.jl" && VERSION ≥ v"0.7.0-DEV" && continue
     include(file)
 end


### PR DESCRIPTION
In Julia0.7 they require current master of IntervalArithmetics