### PR TITLE
Add Taylor1 constructors; fix #183

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -53,8 +53,6 @@ function Taylor1(x::T, order::Int) where {T<:Number}
     v[1] = x
     return Taylor1(v, order)
 end
-Taylor1(x::T) where {T<:Number} = Taylor1(x, 0)
-Taylor1{T}(x::S) where {T<:Number, S<:Union{Real, Complex}} = Taylor1([convert(T,x)], 0)
 
 # Shortcut to define Taylor1 independent variables
 """
@@ -197,10 +195,12 @@ TaylorN(::Type{T}, nv::Int; order::Int=get_order()) where {T<:Number} =
     return TaylorN( [HomogeneousPolynomial(T, nv)], order )
 TaylorN(nv::Int; order::Int=get_order()) = TaylorN(Float64, nv, order=order)
 
-
 # A `Number` which is not an `AbstractSeries`
 const NumberNotSeries = Union{setdiff(subtypes(Number), [AbstractSeries])...}
 
 # A `Number` which is not `TaylorN` nor a `HomogeneousPolynomial`
 const NumberNotSeriesN =
     Union{setdiff(subtypes(Number), [AbstractSeries])..., Taylor1}
+
+## Additional Taylor1 outer constructor ##
+Taylor1{T}(x::S) where {T<:Number, S<:NumberNotSeries} = Taylor1([convert(T,x)], 0)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -44,6 +44,7 @@ struct Taylor1{T<:Number} <: AbstractSeries{T}
 end
 
 ## Outer constructors ##
+Taylor1{T}(x::S) where {T<:Number, S<:Number} = convert(Taylor1{T}, x)
 Taylor1(x::Taylor1{T}) where {T<:Number} = x
 Taylor1(coeffs::Array{T,1}, order::Int) where {T<:Number} = Taylor1{T}(coeffs, order)
 Taylor1(coeffs::Array{T,1}) where {T<:Number} = Taylor1(coeffs, length(coeffs)-1)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -44,7 +44,7 @@ struct Taylor1{T<:Number} <: AbstractSeries{T}
 end
 
 ## Outer constructors ##
-Taylor1{T}(x::S) where {T<:Number, S<:Number} = convert(Taylor1{T}, x)
+Taylor1{T}(x::S) where {T<:Number, S<:Union{Real, Complex}} = convert(Taylor1{T}, x)
 Taylor1(x::Taylor1{T}) where {T<:Number} = x
 Taylor1(coeffs::Array{T,1}, order::Int) where {T<:Number} = Taylor1{T}(coeffs, order)
 Taylor1(coeffs::Array{T,1}) where {T<:Number} = Taylor1(coeffs, length(coeffs)-1)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -54,7 +54,7 @@ function Taylor1(x::T, order::Int) where {T<:Number}
     return Taylor1(v, order)
 end
 Taylor1(x::T) where {T<:Number} = Taylor1(x, 0)
-Taylor1{T}(x::S) where {T<:Number, S<:Union{Real, Complex}} = Taylor1([convert(T,b)], 0)
+Taylor1{T}(x::S) where {T<:Number, S<:Union{Real, Complex}} = Taylor1([convert(T,x)], 0)
 
 # Shortcut to define Taylor1 independent variables
 """

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -44,7 +44,6 @@ struct Taylor1{T<:Number} <: AbstractSeries{T}
 end
 
 ## Outer constructors ##
-Taylor1{T}(x::S) where {T<:Number, S<:Union{Real, Complex}} = convert(Taylor1{T}, x)
 Taylor1(x::Taylor1{T}) where {T<:Number} = x
 Taylor1(coeffs::Array{T,1}, order::Int) where {T<:Number} = Taylor1{T}(coeffs, order)
 Taylor1(coeffs::Array{T,1}) where {T<:Number} = Taylor1(coeffs, length(coeffs)-1)
@@ -54,6 +53,8 @@ function Taylor1(x::T, order::Int) where {T<:Number}
     v[1] = x
     return Taylor1(v, order)
 end
+Taylor1(x::T) where {T<:Number} = Taylor1(x, 0)
+Taylor1{T}(x::S) where {T<:Number, S<:Union{Real, Complex}} = Taylor1([convert(T,b)], 0)
 
 # Shortcut to define Taylor1 independent variables
 """

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -481,19 +481,19 @@ eeuler = Base.MathConstants.e
         @test a[i]*(180/pi) == b[i]
     end
 
+    # Test additional Taylor1 constructors
+    @test Taylor1{Float64}(true) == Taylor1([1.0])
+    @test Taylor1{Float64}(false) == Taylor1([0.0])
+    @test Taylor1{Int}(true) == Taylor1([1])
+    @test Taylor1{Int}(false) == Taylor1([0])
+
+    # Test use of `inv` for computation of matrix inverse of `Matrix{Taylor1{Float64}}`
     a = rand(3, 3)
     b = Taylor1.(a, 5)
     binv = inv(b)
     I_t1_5 = Taylor1.(Matrix{Float64}(I, size(b)), 5) # 5x5 Taylor1{Float64} identity matrix, order 5
-    @test norm(b*binv - I_t1_5, Inf) ≤ 1e-14
-    @test norm(binv*b - I_t1_5, Inf) ≤ 1e-14
-
-    @test Taylor1(true) == Taylor1(1.0)
-    @test Taylor1(false) == Taylor1(0.0)
-    @test Taylor1{Float64}(true) == Taylor1(1.0)
-    @test Taylor1{Float64}(false) == Taylor1(0.0)
-    @test Taylor1{Int}(true) == Taylor1{Int}(1)
-    @test Taylor1{Int}(false) == Taylor1{Int}(0)
+    @test norm(b*binv - I_t1_5, Inf) ≤ 1e-12
+    @test norm(binv*b - I_t1_5, Inf) ≤ 1e-12
 end
 
 @testset "Matrix multiplication for Taylor1" begin

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -480,6 +480,13 @@ eeuler = Base.MathConstants.e
     for i in 0:2
         @test a[i]*(180/pi) == b[i]
     end
+
+    a = rand(3, 3)
+    b = Taylor1.(a, 5)
+    binv = inv(b)
+    I_t1_5 = Taylor1.(Matrix{Float64}(I, size(b)), 5) # 5x5 Taylor1{Float64} matrix, order 5
+    @test norm(b*binv - I_t1_5, Inf) ≤ 1e-14
+    @test norm(binv*b - I_t1_5, Inf) ≤ 1e-14
 end
 
 @testset "Matrix multiplication for Taylor1" begin

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -484,7 +484,7 @@ eeuler = Base.MathConstants.e
     a = rand(3, 3)
     b = Taylor1.(a, 5)
     binv = inv(b)
-    I_t1_5 = Taylor1.(Matrix{Float64}(I, size(b)), 5) # 5x5 Taylor1{Float64} matrix, order 5
+    I_t1_5 = Taylor1.(Matrix{Float64}(I, size(b)), 5) # 5x5 Taylor1{Float64} identity matrix, order 5
     @test norm(b*binv - I_t1_5, Inf) ≤ 1e-14
     @test norm(binv*b - I_t1_5, Inf) ≤ 1e-14
 

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -487,6 +487,13 @@ eeuler = Base.MathConstants.e
     I_t1_5 = Taylor1.(Matrix{Float64}(I, size(b)), 5) # 5x5 Taylor1{Float64} matrix, order 5
     @test norm(b*binv - I_t1_5, Inf) ≤ 1e-14
     @test norm(binv*b - I_t1_5, Inf) ≤ 1e-14
+
+    @test Taylor1(true) == Taylor1(1.0)
+    @test Taylor1(false) == Taylor1(0.0)
+    @test Taylor1{Float64}(true) == Taylor1(1.0)
+    @test Taylor1{Float64}(false) == Taylor1(0.0)
+    @test Taylor1{Int}(true) == Taylor1{Int}(1)
+    @test Taylor1{Int}(false) == Taylor1{Int}(0)
 end
 
 @testset "Matrix multiplication for Taylor1" begin


### PR DESCRIPTION
This PR aims to solve #183 by adding outer `Taylor1` constructors which were handled previously by falling back to `convert`. Corresponding tests were added. Comments, suggestions and reviews are very welcome and appreciated!