### PR TITLE
Address observations to paper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ script:
 after_success:
   - julia -e 'import Pkg; ps=Pkg.PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps)'
   - julia -e 'import TaylorSeries; include(joinpath(dirname(pathof(TaylorSeries)), "../docs", "make.jl"))'
-  - julia -e 'Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
 
 sudo: false

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -36,6 +36,7 @@ evaluate!
 taylor_expand
 update!
 derivative
+differentiate
 integrate
 gradient
 jacobian

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,6 +33,9 @@ pkg> add("TaylorSeries")
 - [PowerSeries.jl](https://github.com/jwmerrill/PowerSeries.jl): Truncated power series for Julia
 - [MultivariatePolynomials.jl](https://github.com/JuliaAlgebra/MultivariatePolynomials.jl): Multivariate polynomials interface
 - [AbstractAlgebra.jl](https://github.com/Nemocas/AbstractAlgebra.jl): Generic abstract algebra functionality in pure Julia
+- [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl): Forward Mode Automatic Differentiation for Julia
+- [ReverseDiff.jl](https://github.com/JuliaDiff/ReverseDiff.jl): Reverse Mode Automatic Differentiation for Julia
+- [HyperDualNumbers.jl](https://github.com/JuliaDiff/HyperDualNumbers.jl): Julia implementation of HyperDualNumbers
 
 ### Acknowledgments
 

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -418,7 +418,7 @@ xysq == x^2 + y^2
 ```
 
 Functions to compute the gradient, Jacobian and
-Hessian have also been implemented; please note that these
+Hessian have also been implemented; note that these
 functions *are not* exported, so its use require the
 prefix `TaylorSeries`. Using the
 polynomials ``p = x^3 + 2x^2 y - 7 x + 2`` and ``q = y-x^4`` defined above,

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -417,20 +417,22 @@ xysq == x^2 + y^2
 ```
 
 Functions to compute the gradient, Jacobian and
-Hessian have also been implemented. Using the
+Hessian have also been implemented; please note that these
+functions *are not* exported, so its use require the
+prefix `TaylorSeries`. Using the
 polynomials ``p = x^3 + 2x^2 y - 7 x + 2`` and ``q = y-x^4`` defined above,
-we may use [`gradient`](@ref) (or `∇`); the results are of
+we may use [`TaylorSeries.gradient`](@ref) (or `∇`); the results are of
 type `Array{TaylorN{T},1}`. To compute the Jacobian and Hessian of a vector field
-evaluated at a point, we use respectively [`jacobian`](@ref) and
-[`hessian`](@ref):
+evaluated at a point, we use respectively [`TaylorSeries.jacobian`](@ref) and
+[`TaylorSeries.hessian`](@ref):
 
 ```@repl userguide
 ∇(p)
-gradient( q )
+TaylorSeries.gradient( q )
 r = p-q-2*p*q
-hessian(ans)
-jacobian([p,q], [2,1])
-hessian(r, [1.0,1.0])
+TaylorSeries.hessian(ans)
+TaylorSeries.jacobian([p,q], [2,1])
+TaylorSeries.hessian(r, [1.0,1.0])
 ```
 
 Other specific applications are described in the

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -138,7 +138,8 @@ rationalize(expon[3])
 ```
 
 Differentiating and integrating is straightforward for polynomial expansions in
-one variable, using [`derivative`](@ref) and [`integrate`](@ref). These
+one variable, using [`derivative`](@ref) and [`integrate`](@ref). (The
+function [`differentiate`](@ref) is an exact synonym of `derivative`.) These
 functions return the corresponding [`Taylor1`](@ref) expansions.
 The last coefficient of a derivative is set to zero to keep the
 same order as the original polynomial; for the integral, an
@@ -153,7 +154,7 @@ integrate(exp(t))
 integrate( exp(t), 1.0)
 integrate( derivative( exp(-t)), 1.0 ) == exp(-t)
 derivative(1, exp(shift_taylor(1.0))) == exp(1.0)
-derivative(5, exp(shift_taylor(1.0))) == exp(1.0) # 5-th derivative of `exp(1+t)`
+differentiate(5, exp(shift_taylor(1.0))) == exp(1.0) # 5-th derivative of `exp(1+t)`
 ```
 
 To evaluate a Taylor series at a given point, Horner's rule is used via the

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -49,9 +49,8 @@ export getcoeff, derivative, integrate, differentiate,
     get_order, get_numvars,
     set_variables, get_variables,
     get_variable_names, get_variable_symbols,
-    # jacobian, hessian,
-    ∇, jacobian!, hessian!,
-    taylor_expand, update!, constant_term
+    # jacobian, hessian, jacobian!, hessian!,
+    ∇, taylor_expand, update!, constant_term
 
 include("parameters.jl")
 include("hash_tables.jl")

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -22,7 +22,7 @@ using SparseArrays: SparseMatrixCSC
 using Markdown
 import LinearAlgebra: norm, mul!
 if VERSION ≥ v"1.0.0"
-    export gradient
+    # export gradient
 else
     import LinearAlgebra: gradient
 end
@@ -49,7 +49,8 @@ export getcoeff, derivative, integrate,
     get_order, get_numvars,
     set_variables, get_variables,
     get_variable_names, get_variable_symbols,
-    ∇, jacobian, jacobian!, hessian, hessian!,
+    # jacobian, hessian,
+    ∇, jacobian!, hessian!,
     taylor_expand, update!, constant_term
 
 include("parameters.jl")

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -43,7 +43,7 @@ import Base: zero, one, zeros, ones, isinf, isnan, iszero,
 
 export Taylor1, TaylorN, HomogeneousPolynomial, AbstractSeries
 
-export getcoeff, derivative, integrate,
+export getcoeff, derivative, integrate, differentiate,
     evaluate, evaluate!, inverse,
     show_params_TaylorN, show_monomials, displayBigO, use_show_default,
     get_order, get_numvars,

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -215,7 +215,7 @@ function gradient(f::TaylorN)
     end
     return grad
 end
-const ∇ = gradient
+const ∇ = TaylorSeries.gradient
 
 """
 ```

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -12,6 +12,8 @@
 
 Return the `Taylor1` polynomial of the differential of `a::Taylor1`.
 The last coefficient is set to zero.
+
+The function `differentiate` is an exact synonym of `derivative`.
 """
 function derivative(a::Taylor1)
     res = zero(a)
@@ -21,6 +23,13 @@ function derivative(a::Taylor1)
     end
     return res
 end
+
+"""
+    differentiate
+
+An exact synonym of [`derivative`](@ref).
+"""
+const differentiate = derivative
 
 """
     derivative!(res, a) --> nothing

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -156,7 +156,7 @@ eeuler = Base.MathConstants.e
     @test (rem(1+xT,1.0))[0] == 0
     @test abs(1-xT)  == 1-xT
     @test abs(-1-xT)  == 1+xT
-    @test derivative(yH,1) == derivative(xH, :x₂)
+    @test differentiate(yH,1) == differentiate(xH, :x₂)
     @test derivative(mod2pi(2pi+yT^3),2) == derivative(yT^3, :x₂)
     @test derivative(yT^3, :x₂) == derivative(yT^3, (0,1))
     @test derivative(yT) == zeroT == derivative(yT, (1,0))

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -471,9 +471,9 @@ eeuler = Base.MathConstants.e
     @test ∇(f2) == [2*xT - 4*xT^3, TaylorN(1,0)]
     @test TaylorSeries.jacobian([f1,f2], [2,1]) == TaylorSeries.jacobian( [g1(xT+2,yT+1), g2(xT+2,yT+1)] )
     jac = Array{Int64}(undef, 2, 2)
-    jacobian!(jac, [g1(xT+2,yT+1), g2(xT+2,yT+1)])
+    TaylorSeries.jacobian!(jac, [g1(xT+2,yT+1), g2(xT+2,yT+1)])
     @test jac == TaylorSeries.jacobian( [g1(xT+2,yT+1), g2(xT+2,yT+1)] )
-    jacobian!(jac, [f1,f2], [2,1])
+    TaylorSeries.jacobian!(jac, [f1,f2], [2,1])
     @test jac == TaylorSeries.jacobian([f1,f2], [2,1])
     @test TaylorSeries.hessian( f1*f2 ) ==
         [derivative((2,0), f1*f2) derivative((1,1), (f1*f2));
@@ -486,16 +486,16 @@ eeuler = Base.MathConstants.e
     @test TaylorSeries.hessian(f1-f2-2*f1*f2) == (TaylorSeries.hessian(f1-f2-2*f1*f2))'
     @test TaylorSeries.hessian(f1-f2,[1,-1]) == TaylorSeries.hessian(g1(xT+1,yT-1)-g2(xT+1,yT-1))
     hes = Array{Int64}(undef, 2, 2)
-    hessian!(hes, f1*f2)
+    TaylorSeries.hessian!(hes, f1*f2)
     @test hes == TaylorSeries.hessian(f1*f2)
     @test [xT yT]*hes*[xT, yT] == [ 2*TaylorN((f1*f2)[2]) ]
-    hessian!(hes, f1^2)
+    TaylorSeries.hessian!(hes, f1^2)
     @test hes/2 == [ [49,0] [0,12] ]
-    hessian!(hes, f1-f2-2*f1*f2)
+    TaylorSeries.hessian!(hes, f1-f2-2*f1*f2)
     @test hes == hes'
     hes1 = Array{Int64}(undef, 2, 2)
-    hessian!(hes1, f1-f2,[1,-1])
-    hessian!(hes, g1(xT+1,yT-1)-g2(xT+1,yT-1))
+    TaylorSeries.hessian!(hes1, f1-f2,[1,-1])
+    TaylorSeries.hessian!(hes, g1(xT+1,yT-1)-g2(xT+1,yT-1))
     @test hes1 == hes
 
     use_show_default(true)

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -467,27 +467,27 @@ eeuler = Base.MathConstants.e
     g2(x, y) = y + x^2 - x^4
     f1 = g1(xT, yT)
     f2 = g2(xT, yT)
-    @test gradient(f1) == [ 3*xT^2-4*xT*yT-TaylorN(7,0), 6*yT-2*xT^2 ]
+    @test TaylorSeries.gradient(f1) == [ 3*xT^2-4*xT*yT-TaylorN(7,0), 6*yT-2*xT^2 ]
     @test ∇(f2) == [2*xT - 4*xT^3, TaylorN(1,0)]
-    @test jacobian([f1,f2], [2,1]) == jacobian( [g1(xT+2,yT+1), g2(xT+2,yT+1)] )
+    @test TaylorSeries.jacobian([f1,f2], [2,1]) == TaylorSeries.jacobian( [g1(xT+2,yT+1), g2(xT+2,yT+1)] )
     jac = Array{Int64}(undef, 2, 2)
     jacobian!(jac, [g1(xT+2,yT+1), g2(xT+2,yT+1)])
-    @test jac == jacobian( [g1(xT+2,yT+1), g2(xT+2,yT+1)] )
+    @test jac == TaylorSeries.jacobian( [g1(xT+2,yT+1), g2(xT+2,yT+1)] )
     jacobian!(jac, [f1,f2], [2,1])
-    @test jac == jacobian([f1,f2], [2,1])
-    @test hessian( f1*f2 ) ==
+    @test jac == TaylorSeries.jacobian([f1,f2], [2,1])
+    @test TaylorSeries.hessian( f1*f2 ) ==
         [derivative((2,0), f1*f2) derivative((1,1), (f1*f2));
          derivative((1,1), f1*f2) derivative((0,2), (f1*f2))] == [4 -7; -7 0]
-    @test hessian( f1*f2, [xT, yT] ) ==
+    @test TaylorSeries.hessian( f1*f2, [xT, yT] ) ==
         [derivative(f1*f2, (2,0)) derivative((f1*f2), (1,1));
          derivative(f1*f2, (1,1)) derivative((f1*f2), (0,2))]
-    @test [xT yT]*hessian(f1*f2)*[xT, yT] == [ 2*TaylorN((f1*f2)[2]) ]
-    @test hessian(f1^2)/2 == [ [49,0] [0,12] ]
-    @test hessian(f1-f2-2*f1*f2) == (hessian(f1-f2-2*f1*f2))'
-    @test hessian(f1-f2,[1,-1]) == hessian(g1(xT+1,yT-1)-g2(xT+1,yT-1))
+    @test [xT yT]*TaylorSeries.hessian(f1*f2)*[xT, yT] == [ 2*TaylorN((f1*f2)[2]) ]
+    @test TaylorSeries.hessian(f1^2)/2 == [ [49,0] [0,12] ]
+    @test TaylorSeries.hessian(f1-f2-2*f1*f2) == (TaylorSeries.hessian(f1-f2-2*f1*f2))'
+    @test TaylorSeries.hessian(f1-f2,[1,-1]) == TaylorSeries.hessian(g1(xT+1,yT-1)-g2(xT+1,yT-1))
     hes = Array{Int64}(undef, 2, 2)
     hessian!(hes, f1*f2)
-    @test hes == hessian(f1*f2)
+    @test hes == TaylorSeries.hessian(f1*f2)
     @test [xT yT]*hes*[xT, yT] == [ 2*TaylorN((f1*f2)[2]) ]
     hessian!(hes, f1^2)
     @test hes/2 == [ [49,0] [0,12] ]

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -267,5 +267,5 @@ using LinearAlgebra, SparseArrays
     Pv = [rndTN(get_order(), 3), rndTN(get_order(), 3)]
     Qv = convert.(Taylor1{TaylorN{Float64}}, Pv)
 
-    @test jacobian(Pv) == jacobian(Qv)
+    @test TaylorSeries.jacobian(Pv) == TaylorSeries.jacobian(Qv)
 end

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -357,7 +357,7 @@ eeuler = Base.MathConstants.e
     @test evaluate(v, complex(0.0,0.2)) ==
         [complex(0.0,sinh(0.2)),complex(cos(0.2),sin(-0.2))]
 
-    @test derivative(exp(ta(1.0)), 0) == exp(ta(1.0))
+    @test differentiate(exp(ta(1.0)), 0) == exp(ta(1.0))
     expected_result_approx = Taylor1(convert(Vector{Float64},exp(ta(1.0))[0:10]))
     @test derivative(exp(ta(1.0)), 5) ≈ expected_result_approx atol=eps() rtol=0.0
     expected_result_approx = Taylor1(convert(Vector{Float64},exp(ta(1.0pi))[0:12]),15)


### PR DESCRIPTION
This PR addresses the [observations](https://github.com/openjournals/joss-reviews/issues/1043#issuecomment-443262789) by @tobydriscoll on our submission to JOSS. 

Concretely:
- it adds some pointers to other automatic differentiation packages in the docs; 
- it removes exporting `gradient`, `jacobian` and `hessian`; and
- adds `differentiate` as a synonym of `derivative` (including proper refs in the docs and few tests).

@dpsanders, Do you have any comments/additions/corrections on this?