### PR TITLE
Add quick examples to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ independent variables.
 [![DOI](http://joss.theoj.org/papers/10.21105/joss.01043/status.svg)](https://doi.org/10.21105/joss.01043)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2601941.svg)](https://zenodo.org/record/2601941)
 
-
 #### Authors
 - [Luis Benet](http://www.cicc.unam.mx/~benet/), Instituto de Ciencias Físicas,
 Universidad Nacional Autónoma de México (UNAM)
@@ -20,6 +19,49 @@ Universidad Nacional Autónoma de México (UNAM)
 de Ciencias, Universidad Nacional Autónoma de México (UNAM)
 
 Comments, suggestions and improvements are welcome and appreciated.
+
+#### Examples
+Taylor series in one varaible
+```julia
+julia> using TaylorSeries
+
+julia> t = Taylor1(Float64, 5)
+ 1.0 t + 𝒪(t⁶)
+
+julia> exp(t)
+ 1.0 + 1.0 t + 0.5 t² + 0.16666666666666666 t³ + 0.041666666666666664 t⁴ + 0.008333333333333333 t⁵ + 𝒪(t⁶)
+ 
+ julia> log(1 + t)
+ 1.0 t - 0.5 t² + 0.3333333333333333 t³ - 0.25 t⁴ + 0.2 t⁵ + 𝒪(t⁶)
+ ```
+Multivariate Taylor series
+ ```julia
+julia> x, y = set_variables("x y", order=2);
+
+julia> exp(x + y)
+ 1.0 + 1.0 x + 1.0 y + 0.5 x² + 1.0 x y + 0.5 y² + 𝒪(‖x‖³)
+ 
+```
+Differential and integral calculus on Taylor series:
+```julia
+julia> x, y = set_variables("x y", order=4);
+
+julia> p = x^3 + 2x^2 * y - 7x + 2
+ 2.0 - 7.0 x + 1.0 x³ + 2.0 x² y + 𝒪(‖x‖⁵)
+
+julia> ∇(p)
+2-element Array{TaylorN{Float64},1}:
+  - 7.0 + 3.0 x² + 4.0 x y + 𝒪(‖x‖⁵)
+                    2.0 x² + 𝒪(‖x‖⁵)
+
+julia> integrate(p, 1)
+ 2.0 x - 3.5 x² + 0.25 x⁴ + 0.6666666666666666 x³ y + 𝒪(‖x‖⁵)
+
+julia> integrate(p, 2)
+ 2.0 y - 7.0 x y + 1.0 x³ y + 1.0 x² y² + 𝒪(‖x‖⁵)
+```
+
+For more details, please see the [docs](http://www.juliadiff.org/TaylorSeries.jl/stable).
 
 #### License
 


### PR DESCRIPTION
Personally, when I visit a package repo I want to see at least some simple code examples right away. Currently, one has to first navigate to the docs, and then from the main docs page to the user guide before they ever see a code example.

This PR adds some flashy demos (taken from the docs) to the REAME so that potential users can see what an awesome package this is right from the start. 