### PR TITLE
LU-factorize without pivoting for `inv` of `Taylor1` matrices

### DIFF
--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -23,10 +23,12 @@ using Markdown
 using Requires
 
 using LinearAlgebra: norm, mul!,
-    lu, istriu, triu!, istril, tril!, UpperTriangular, LowerTriangular,
-    LinearAlgebra.inv!, LinearAlgebra.checksquare
+    lu, lu!, LinearAlgebra.lutype, LinearAlgebra.copy_oftype,
+    LinearAlgebra.issuccess
+    # istriu, triu!, istril, tril!, UpperTriangular, LowerTriangular,
+    # LinearAlgebra.inv!, LinearAlgebra.checksquare
 
-import LinearAlgebra: norm, mul!
+import LinearAlgebra: norm, mul!, lu
 
 import Base: ==, +, -, *, /, ^
 

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -22,6 +22,10 @@ using SparseArrays: SparseMatrixCSC
 using Markdown
 using Requires
 
+using LinearAlgebra: norm, mul!,
+    lu, istriu, triu!, istril, tril!, UpperTriangular, LowerTriangular,
+    LinearAlgebra.inv!, LinearAlgebra.checksquare
+
 import LinearAlgebra: norm, mul!
 
 import Base: ==, +, -, *, /, ^

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -506,21 +506,22 @@ end
 
 @testset "Test `inv` for `Matrix{Taylor1{Float64}}``" begin
     t = Taylor1(5)
-    a = rand(3, 3)
-    b = a .+ zero(t)
-    binv = inv(b)
-    I_t_5 = UniformScaling(one(Taylor1(5))) # 3x3 Taylor1{Float64} identity matrix, order 5
-    @test norm(b*binv - I_t_5, Inf) ≤ 1e-11
-    @test norm(binv*b - I_t_5, Inf) ≤ 1e-11
-    @test norm(triu(b)*inv(UpperTriangular(b)) - I_t_5, Inf) ≤ 1e-11
-    @test norm(inv(LowerTriangular(b))*tril(b) - I_t_5, Inf) ≤ 1e-11
 
-    b = a .+ t
+    a = Diagonal(rand(0:10,3)) + rand(3, 3)
+    b = Taylor1.(a, 5)
     binv = inv(b)
-    @test norm(b*binv - I_t_5, Inf) ≤ 1e-11
-    @test norm(binv*b - I_t_5, Inf) ≤ 1e-11
-    @test norm(triu(b)*inv(triu(b)) - I_t_5, Inf) ≤ 1e-11
-    @test norm(inv(tril(b))*tril(b) - I_t_5, Inf) ≤ 1e-11
+    @test norm(binv - inv(a), Inf) ≤ 1e-11
+    @test norm(b*binv - I, Inf) ≤ 1e-11
+    @test norm(binv*b - I, Inf) ≤ 1e-11
+    @test norm(triu(b)*inv(UpperTriangular(b)) - I, Inf) ≤ 1e-11
+    @test norm(inv(LowerTriangular(b))*tril(b) - I, Inf) ≤ 1e-11
+
+    b .= b .+ t
+    binv = inv(b)
+    @test norm(b*binv - I, Inf) ≤ 1e-11
+    @test norm(binv*b - I, Inf) ≤ 1e-11
+    @test norm(triu(b)*inv(triu(b)) - I, Inf) ≤ 1e-11
+    @test norm(inv(tril(b))*tril(b) - I, Inf) ≤ 1e-11
 end
 
 @testset "Matrix multiplication for Taylor1" begin

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -502,14 +502,25 @@ eeuler = Base.MathConstants.e
     @test Taylor1{Float64}(false) == Taylor1([0.0])
     @test Taylor1{Int}(true) == Taylor1([1])
     @test Taylor1{Int}(false) == Taylor1([0])
+end
 
-    # Test use of `inv` for computation of matrix inverse of `Matrix{Taylor1{Float64}}`
+@testset "Test `inv` for `Matrix{Taylor1{Float64}}``" begin
+    t = Taylor1(5)
     a = rand(3, 3)
-    b = Taylor1.(a, 5)
+    b = a .+ zero(t)
     binv = inv(b)
-    I_t1_5 = Taylor1.(Matrix{Float64}(I, size(b)), 5) # 5x5 Taylor1{Float64} identity matrix, order 5
-    @test norm(b*binv - I_t1_5, Inf) ≤ 1e-12
-    @test norm(binv*b - I_t1_5, Inf) ≤ 1e-12
+    I_t_5 = UniformScaling(one(Taylor1(5))) # 3x3 Taylor1{Float64} identity matrix, order 5
+    @test norm(b*binv - I_t_5, Inf) ≤ 1e-11
+    @test norm(binv*b - I_t_5, Inf) ≤ 1e-11
+    @test norm(triu(b)*inv(UpperTriangular(b)) - I_t_5, Inf) ≤ 1e-11
+    @test norm(inv(LowerTriangular(b))*tril(b) - I_t_5, Inf) ≤ 1e-11
+
+    b = a .+ t
+    binv = inv(b)
+    @test norm(b*binv - I_t_5, Inf) ≤ 1e-11
+    @test norm(binv*b - I_t_5, Inf) ≤ 1e-11
+    @test norm(triu(b)*inv(triu(b)) - I_t_5, Inf) ≤ 1e-11
+    @test norm(inv(tril(b))*tril(b) - I_t_5, Inf) ≤ 1e-11
 end
 
 @testset "Matrix multiplication for Taylor1" begin

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -506,22 +506,30 @@ end
 
 @testset "Test `inv` for `Matrix{Taylor1{Float64}}``" begin
     t = Taylor1(5)
-
     a = Diagonal(rand(0:10,3)) + rand(3, 3)
+    ainv = inv(a)
     b = Taylor1.(a, 5)
     binv = inv(b)
-    @test norm(binv - inv(a), Inf) ≤ 1e-11
-    @test norm(b*binv - I, Inf) ≤ 1e-11
-    @test norm(binv*b - I, Inf) ≤ 1e-11
-    @test norm(triu(b)*inv(UpperTriangular(b)) - I, Inf) ≤ 1e-11
-    @test norm(inv(LowerTriangular(b))*tril(b) - I, Inf) ≤ 1e-11
+    tol = 1.0e-11
 
-    b .= b .+ t
-    binv = inv(b)
-    @test norm(b*binv - I, Inf) ≤ 1e-11
-    @test norm(binv*b - I, Inf) ≤ 1e-11
-    @test norm(triu(b)*inv(triu(b)) - I, Inf) ≤ 1e-11
-    @test norm(inv(tril(b))*tril(b) - I, Inf) ≤ 1e-11
+    for its = 1:10
+        a .= Diagonal(rand(2:12,3)) + rand(3, 3)
+        ainv .= inv(a)
+        b .= Taylor1.(a, 5)
+        binv .= inv(b)
+        @test norm(binv - ainv, Inf) ≤ tol
+        @test norm(b*binv - I, Inf) ≤ tol
+        @test norm(binv*b - I, Inf) ≤ tol
+        @test norm(triu(b)*inv(UpperTriangular(b)) - I, Inf) ≤ tol
+        @test norm(inv(LowerTriangular(b))*tril(b) - I, Inf) ≤ tol
+
+        b .= b .+ t
+        binv .= inv(b)
+        @test norm(b*binv - I, Inf) ≤ tol
+        @test norm(binv*b - I, Inf) ≤ tol
+        @test norm(triu(b)*inv(triu(b)) - I, Inf) ≤ tol
+        @test norm(inv(tril(b))*tril(b) - I, Inf) ≤ tol
+    end
 end
 
 @testset "Matrix multiplication for Taylor1" begin


### PR DESCRIPTION
This PR adds a specialized methods of `inv` for matrices with `Taylor1` coefficients, which avoids pivoting in `lu`. This is related to recent changes (https://github.com/JuliaLang/julia/pull/32989) in Julia stdlib/LinearAlgebra, which now uses pivoting by default.

Fixes #221