### PR TITLE
Initialize coefficients of mutated array in mutating functions

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -291,7 +291,12 @@ for T in (:Taylor1, :TaylorN)
     @eval @inline function mul!(c::$T{T}, a::$T{T}, b::$T{T}, k::Int) where {T}
 
         # c[k] = zero( a[k] )
-        @inbounds for i = 0:k
+        if $T == Taylor1
+            c[k] = a[0] * b[k]
+        else
+            mul!(c[k], a[0], b[k])
+        end
+        @inbounds for i = 1:k
             if $T == Taylor1
                 c[k] += a[i] * b[k-i]
             else

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -495,7 +495,7 @@ term of the denominator.
     end
 
     imin = max(0, k+ordfact-b.order)
-    c[k] = c[imin] * b[k+ordfact-imin]
+    @inbounds c[k] = c[imin] * b[k+ordfact-imin]
     @inbounds for i = imin+1:k-1
         c[k] += c[i] * b[k+ordfact-i]
     end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -291,10 +291,10 @@ for T in (:Taylor1, :TaylorN)
     @eval @inline function mul!(c::$T{T}, a::$T{T}, b::$T{T}, k::Int) where {T}
 
         # c[k] = zero( a[k] )
-        @inbounds if $T == Taylor1
-            c[k] = a[0] * b[k]
+        if $T == Taylor1
+            @inbounds c[k] = a[0] * b[k]
         else
-            mul!(c[k], a[0], b[k])
+            @inbounds mul!(c[k], a[0], b[k])
         end
         @inbounds for i = 1:k
             if $T == Taylor1

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -290,7 +290,6 @@ end
 for T in (:Taylor1, :TaylorN)
     @eval @inline function mul!(c::$T{T}, a::$T{T}, b::$T{T}, k::Int) where {T}
 
-        # c[k] = zero( a[k] )
         if $T == Taylor1
             @inbounds c[k] = a[0] * b[k]
         else

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -291,7 +291,7 @@ for T in (:Taylor1, :TaylorN)
     @eval @inline function mul!(c::$T{T}, a::$T{T}, b::$T{T}, k::Int) where {T}
 
         # c[k] = zero( a[k] )
-        if $T == Taylor1
+        @inbounds if $T == Taylor1
             c[k] = a[0] * b[k]
         else
             mul!(c[k], a[0], b[k])

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -494,8 +494,9 @@ term of the denominator.
         return nothing
     end
 
-    @inbounds for i = 0:k-1
-        k+ordfact-i > b.order && continue
+    imin = max(0, k+ordfact-b.order)
+    c[k] = c[imin] * b[k+ordfact-imin]
+    @inbounds for i = imin+1:k-1
         c[k] += c[i] * b[k+ordfact-i]
     end
     if k+ordfact ≤ b.order

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -191,8 +191,12 @@ for T in (:Taylor1, :TaylorN)
                 @inbounds c[0] = exp(constant_term(a))
                 return nothing
             end
-
-            @inbounds for i = 0:k-1
+            if $T == Taylor1
+                @inbounds c[k] = k * a[k] * c[0]
+            else
+                @inbounds mul!(c[k], k * a[k], c[0])
+            end
+            @inbounds for i = 1:k-1
                 if $T == Taylor1
                     c[k] += (k-i) * a[k-i] * c[i]
                 else
@@ -200,7 +204,6 @@ for T in (:Taylor1, :TaylorN)
                 end
             end
             @inbounds c[k] = c[k] / k
-
             return nothing
         end
 
@@ -208,9 +211,17 @@ for T in (:Taylor1, :TaylorN)
             if k == 0
                 @inbounds c[0] = log(constant_term(a))
                 return nothing
+            elseif k == 1
+                @inbounds c[1] = a[1] / constant_term(a)
+                return nothing
             end
 
-            @inbounds for i = 1:k-1
+            if $T == Taylor1
+                @inbounds c[k] = (k-1) * a[1] * c[k-1]
+            else
+                @inbounds mul!(c[k], (k-1)*a[1], c[k-1])
+            end
+            @inbounds for i = 2:k-1
                 if $T == Taylor1
                     c[k] += (k-i) * a[i] * c[k-i]
                 else
@@ -218,7 +229,6 @@ for T in (:Taylor1, :TaylorN)
                 end
             end
             @inbounds c[k] = (a[k] - c[k]/k) / constant_term(a)
-
             return nothing
         end
 
@@ -229,7 +239,15 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
 
-            @inbounds for i = 1:k
+            x = a[1]
+            if $T == Taylor1
+                @inbounds s[k] = x * c[k-1]
+                @inbounds c[k] = -x * s[k-1]
+            else
+                mul!(s[k], x, c[k-1])
+                mul!(c[k], -x, s[k-1])
+            end
+            @inbounds for i = 2:k
                 x = i * a[i]
                 if $T == Taylor1
                     s[k] += x * c[k-i]
@@ -253,7 +271,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
 
-            @inbounds for i = 0:k-1
+            if $T == Taylor1
+                @inbounds c[k] = (k-1) * a[k-1] * c2[1]
+            else
+                @inbounds mul!(c[k], (k-1) * a[k-1], c2[1])
+            end
+            @inbounds for i = 1:k-1
                 if $T == Taylor1
                     c[k] += (k-i) * a[k-i] * c2[i]
                 else
@@ -274,7 +297,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
 
-            @inbounds for i in 1:k-1
+            if $T == Taylor1
+                @inbounds c[k] = (k-1) * r[1] * c[k-1]
+            else
+                @inbounds mul!(c[k], (k-1) * r[1], c[k-1])
+            end
+            @inbounds for i in 2:k-1
                 if $T == Taylor1
                     c[k] += (k-i) * r[i] * c[k-i]
                 else
@@ -294,7 +322,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
 
-            @inbounds for i in 1:k-1
+            if $T == Taylor1
+                @inbounds c[k] = (k-1) * r[1] * c[k-1]
+            else
+                @inbounds mul!(c[k], (k-1) * r[1], c[k-1])
+            end
+            @inbounds for i in 2:k-1
                 if $T == Taylor1
                     c[k] += (k-i) * r[i] * c[k-i]
                 else
@@ -314,7 +347,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
 
-            @inbounds for i in 1:k-1
+            if $T == Taylor1
+                @inbounds c[k] = (k-1) * r[1] * c[k-1]
+            else
+                @inbounds mul!(c[k], (k-1) * r[1], c[k-1])
+            end
+            @inbounds for i in 2:k-1
                 if $T == Taylor1
                     c[k] += (k-i) * r[i] * c[k-i]
                 else
@@ -333,7 +371,15 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
 
-            @inbounds for i = 1:k
+            x = a[1]
+            if $T == Taylor1
+                @inbounds s[k] = x * c[k-1]
+                @inbounds c[k] = x * s[k-1]
+            else
+                @inbounds mul!(s[k], x, c[k-1])
+                @inbounds mul!(c[k], x, s[k-1])
+            end
+            @inbounds for i = 2:k
                 x = i * a[i]
                 if $T == Taylor1
                     s[k] += x * c[k-i]
@@ -356,7 +402,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
 
-            @inbounds for i = 0:k-1
+            if $T == Taylor1
+                @inbounds c[k] = k * a[k] * c2[0]
+            else
+                @inbounds mul!(c[k], k * a[k], c2[0])
+            end
+            @inbounds for i = 1:k-1
                 if $T == Taylor1
                     c[k] += (k-i) * a[k-i] * c2[i]
                 else

--- a/src/power.jl
+++ b/src/power.jl
@@ -433,8 +433,10 @@ coefficient, which must be even.
 
     kodd = (k - k0)%2
     kend = div(k - k0 - 2 + kodd, 2)
-    @inbounds for i = k0+1:k0+kend
-        (k+k0-i > a.order) || (i > a.order) && continue
+    imax = min(k0+kend, a.order)
+    imin = max(k0+1, k+k0-a.order)
+    imin ≤ imax && ( @inbounds c[k] = c[imin] * c[k+k0-imin] )
+    @inbounds for i = imin+1:imax
         c[k] += c[i] * c[k+k0-i]
     end
     if k+k0 ≤ a.order

--- a/src/power.jl
+++ b/src/power.jl
@@ -200,6 +200,12 @@ coefficient of `a`.
         return nothing
     end
 
+    # Relevant for positive integer r, to avoid round-off errors
+    if isinteger(r) && (k-l0 > r*findlast(a) > 0)
+        @inbounds c[k-l0] = zero(c[0])
+        return nothing
+    end
+
     imin = max(0,k-a.order)
     aux = r*(k-imin) - imin
     @inbounds c[k-l0] = aux * a[k-imin] * c[imin]

--- a/src/power.jl
+++ b/src/power.jl
@@ -200,15 +200,10 @@ coefficient of `a`.
         return nothing
     end
 
-    # Relevant for positive integer r, to avoid round-off errors
-    if isinteger(r) && (k-l0 > r*findlast(a) > 0)
-        @inbounds c[k-l0] = zero(c[0])
-        return nothing
-    end
-
     imin = max(0,k-a.order)
-    for i = imin:k-l0-1
-        # k-i > a.order && continue
+    aux = r*(k-imin) - imin
+    @inbounds c[k-l0] = aux * a[k-imin] * c[imin]
+    for i = imin+1:k-l0-1
         aux = r*(k-i) - i
         @inbounds c[k-l0] += aux * a[k-i] * c[i]
     end

--- a/test/mutatingfuncts.jl
+++ b/test/mutatingfuncts.jl
@@ -48,7 +48,7 @@ using Test
     TaylorSeries.subst!(res, 1, t2, 2)
     @test res[2] == -1.0
 
-    res = zero(t1)
+    res[3] = rand()
     TaylorSeries.mul!(res, t1, t2, 3)
     @test res[3] == 1.0
     TaylorSeries.mul!(res, res, 2, 3)
@@ -56,10 +56,10 @@ using Test
     TaylorSeries.mul!(res, 0.5, res, 3)
     @test res[3] == 1.0
 
-    res = zero(t1)
     TaylorSeries.div!(res, t2-1, 1+t1, 0)
     TaylorSeries.div!(res, t2-1, 1+t1, 1)
-    @test res == t1-1
+    @test res[0] == (t1-1)[0]
+    @test res[1] == (t1-1)[1]
     TaylorSeries.div!(res, res, 2, 0)
     @test res[0] == -0.5
 

--- a/test/mutatingfuncts.jl
+++ b/test/mutatingfuncts.jl
@@ -56,7 +56,9 @@ using Test
     TaylorSeries.mul!(res, 0.5, res, 3)
     @test res[3] == 1.0
 
+    res[0] = rand()
     TaylorSeries.div!(res, t2-1, 1+t1, 0)
+    res[1] = rand()
     TaylorSeries.div!(res, t2-1, 1+t1, 1)
     @test res[0] == (t1-1)[0]
     @test res[1] == (t1-1)[1]


### PR DESCRIPTION
On current master, arrays which store the results of in-place methods such as `mul!`, require those arrays to be initialized to zero in order to work properly:

```julia
julia> using TaylorSeries

julia> order = 2
2

julia> a = Taylor1(rand(order+1))
 0.3901307590706329 + 0.9302337261932201 t + 0.6610315422490114 t² + 𝒪(t³)

julia> b = Taylor1(rand(order+1))
 0.2612832916798675 + 0.00877818753697479 t + 0.6191465524314967 t² + 𝒪(t³)

julia> c = Taylor1(rand(order+1)) # this array stores the results of mul!
 0.5731001108245433 + 0.21748961305056236 t + 0.08638238016455047 t² + 𝒪(t³)

julia> d = a*b # this is the out-of-place product of a and b
 0.1019346489155403 + 0.2464791709784575 t + 0.42243037784084925 t² + 𝒪(t³)

julia> for i = 0:order
           TaylorSeries.mul!(c, a, b, i)
       end

julia> c == d
false
```
Instead, if we initialize the coefficients of `c` to zero, then things work as expected:
```julia
julia> using TaylorSeries

julia> order = 2
2

julia> a = Taylor1(rand(order+1))
 0.36955349820946815 + 0.6054725203327813 t + 0.996916828899657 t² + 𝒪(t³)

julia> b = Taylor1(rand(order+1))
 0.7519229599490191 + 0.9713889338097239 t + 0.23777103622352547 t² + 𝒪(t³)

julia> c = Taylor1(zeros(order+1)) # this array stores the results of mul!
 0.0 + 𝒪(t³)

julia> d = a*b # this is the out-of-place product of a and b
 0.27787576023317784 + 0.8142488682677665 t + 1.4256230769956608 t² + 𝒪(t³)

julia> for i = 0:order
           TaylorSeries.mul!(c, a, b, i)
       end

julia> c == d
true
```


This PR changes the internals of mutating functions `mul!`, `div!`, `pow!`, `sqrt!`, so that the storing array `c` is not required to be initialized to zero:

```julia
julia> using TaylorSeries

julia> order = 2
2

julia> a = Taylor1(rand(order+1))
 0.5223686459210033 + 0.590802594088681 t + 0.762529408631156 t² + 𝒪(t³)

julia> b = Taylor1(rand(order+1))
 0.15529320411399827 + 0.8192967906969988 t + 0.22329571472836762 t² + 𝒪(t³)

julia> c = Taylor1(rand(order+1))
 0.4577969424667405 + 0.6157155512378607 t + 0.44432155422776276 t² + 𝒪(t³)

julia> d = a*b
 0.08112030075376325 + 0.5197225829987081 t + 0.7191009845124225 t² + 𝒪(t³)

julia> for i = 0:order
           TaylorSeries.mul!(c, a, b, i)
       end

julia> c == d
true
```

I tried to change things as little as possible without adding too much overhead, so performance shouldn't be changed too much, and offline benchmarks with `TaylorIntegration.@taylorize` seem to confirm this, i.e., performance is essentially maintained. This PR was indeed inspired by working with `TaylorIntegration.@taylorize`, where these methods are used intensively, and should simplify life working with it.