### PR TITLE
Fix update! for TaylorN

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
-version = "0.10.3"
+version = "0.10.4"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -262,7 +262,7 @@ end
 
 #update! function for TaylorN
 function update!(a::TaylorN, vals::Vector{T}) where {T<:Number}
-    a.coeffs .= evaluate(a, get_variables() .+ vals).coeffs
+    a.coeffs .= evaluate(a, get_variables(a.order) .+ vals).coeffs
     nothing
 end
 


### PR DESCRIPTION
The current implementation of this function gives `DimensionMismatch` error when the order of the updating polynomial doesn't match the order specified with the `set_variables` function, e.g.

```julia
set_variables([:x, :y], order=6)

xT = TaylorN(Float64, 1, order=3)
yT = TaylorN(Float64, 2, order=3)

update!(xT, [1., 0.]) # gives error
```
This PR fix this behavior by using the same order of the updating polynomial in the `update!` function internals.