### PR TITLE
Add two-arg `atan` method and corresponding tests

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -119,6 +119,12 @@ for T in (:Taylor1, :TaylorN)
             return c
         end
 
+        function atan(a::$T, b::$T)
+            c = atan(a/b)
+            c[0] = atan(constant_term(a), constant_term(b))
+            return c
+        end
+
         sinh(a::$T) = sinhcosh(a)[1]
         cosh(a::$T) = sinhcosh(a)[2]
         function sinhcosh(a::$T)
@@ -363,6 +369,32 @@ for T in (:Taylor1, :TaylorN)
             @inbounds c[k] = (a[k] - c[k]/k) / constant_term(r)
             return nothing
         end
+
+        # @inline function atan!(c::$T{T}, a::$T{T}, b::$T{T}, r::$T{T}, k::Int) where {T}
+        #     if k == 0
+        #         a0 = constant_term(a)
+        #         b0 = constant_term(b)
+        #         @inbounds c[0] = atan( a0, b0 )
+        #         @inbounds r[0] = 1 + a0^2
+        #         return nothing
+        #     end
+
+        #     if $T == Taylor1
+        #         @inbounds c[k] = (k-1) * r[1] * c[k-1]
+        #     else
+        #         @inbounds mul!(c[k], (k-1) * r[1], c[k-1])
+        #     end
+        #     @inbounds for i in 2:k-1
+        #         if $T == Taylor1
+        #             c[k] += (k-i) * r[i] * c[k-i]
+        #         else
+        #             mul!(c[k], (k-i) * r[i], c[k-i])
+        #         end
+        #     end
+        #     @inbounds sqr!(r, a, k)
+        #     @inbounds c[k] = (a[k] - c[k]/k) / constant_term(r)
+        #     return nothing
+        # end
 
         @inline function sinhcosh!(s::$T{T}, c::$T{T}, a::$T{T}, k::Int) where {T}
             if k == 0

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -370,32 +370,6 @@ for T in (:Taylor1, :TaylorN)
             return nothing
         end
 
-        # @inline function atan!(c::$T{T}, a::$T{T}, b::$T{T}, r::$T{T}, k::Int) where {T}
-        #     if k == 0
-        #         a0 = constant_term(a)
-        #         b0 = constant_term(b)
-        #         @inbounds c[0] = atan( a0, b0 )
-        #         @inbounds r[0] = 1 + a0^2
-        #         return nothing
-        #     end
-
-        #     if $T == Taylor1
-        #         @inbounds c[k] = (k-1) * r[1] * c[k-1]
-        #     else
-        #         @inbounds mul!(c[k], (k-1) * r[1], c[k-1])
-        #     end
-        #     @inbounds for i in 2:k-1
-        #         if $T == Taylor1
-        #             c[k] += (k-i) * r[i] * c[k-i]
-        #         else
-        #             mul!(c[k], (k-i) * r[i], c[k-i])
-        #         end
-        #     end
-        #     @inbounds sqr!(r, a, k)
-        #     @inbounds c[k] = (a[k] - c[k]/k) / constant_term(r)
-        #     return nothing
-        # end
-
         @inline function sinhcosh!(s::$T{T}, c::$T{T}, a::$T{T}, k::Int) where {T}
             if k == 0
                 @inbounds s[0] = sinh( constant_term(a) )

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -408,6 +408,8 @@ eeuler = Base.MathConstants.e
     @test evaluate(asin(sin(xT+yT)), [1.0,0.5]) == 1.5
     @test tan(atan(xT+yT)) == xT+yT
     @test atan(tan(xT+yT)) == xT+yT
+    @test atan(sin(1+xT+yT), cos(1+xT+yT)) == atan(sin(1+xT+yT)/cos(1+xT+yT))
+    @test constant_term(atan(sin(3pi/4+xT+yT), cos(3pi/4+xT+yT))) == 3pi/4
     @test asin(xT+yT) + acos(xT+yT) == pi/2
 
     @test -sinh(xT+yT) + cosh(xT+yT) == exp(-(xT+yT))

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -290,6 +290,10 @@ Base.iszero(::SymbNumber) = false
     @test sin(asin(tsquare)) == tsquare
     @test tan(atan(tsquare)) == tsquare
     @test atan(tan(tsquare)) == tsquare
+    @test atan(sin(tsquare)/cos(tsquare)) == atan(sin(tsquare), cos(tsquare))
+    @test constant_term(atan(sin(3pi/4+tsquare), cos(3pi/4+tsquare))) == 3pi/4
+    @test atan(sin(3pi/4+tsquare)/cos(3pi/4+tsquare)) - atan(sin(3pi/4+tsquare), cos(3pi/4+tsquare)) == -pi
+
     @test asin(t) + acos(t) == pi/2
     @test derivative(acos(t)) == - 1/sqrt(1-t^2)
 


### PR DESCRIPTION
This PR adds two-argument methods for `atan` and tests, which hopefully is useful to have in `TaylorSeries.jl`. Things seem to be working for `Taylor1` and `TaylorN`, but I'm not sure if a new in-place `atan!` method is needed as well?