### PR TITLE
Fix zero for TaylorN{Taylor1}

### DIFF
--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -17,7 +17,7 @@ see also [`HomogeneousPolynomial`](@ref).
 module TaylorSeries
 
 
-using InteractiveUtils: subtypes, @which
+using InteractiveUtils: subtypes
 using SparseArrays: SparseMatrixCSC
 using Markdown
 using Requires

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -17,7 +17,7 @@ see also [`HomogeneousPolynomial`](@ref).
 module TaylorSeries
 
 
-using InteractiveUtils: subtypes
+using InteractiveUtils: subtypes, @which
 using SparseArrays: SparseMatrixCSC
 using Markdown
 using Requires

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -33,8 +33,9 @@ for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
 end
 
 ## zero and one ##
-for T in (:Taylor1, :TaylorN), f in (:zero, :one)
-    @eval ($f)(a::$T) = $T(($f)(a[0]), a.order)
+for T in (:Taylor1, :TaylorN)
+    @eval one(a::$T) = $T(one(a[0]), a.order)
+    @eval zero(a::$T) = $T(zero.(a.coeffs))
 end
 
 function zero(a::HomogeneousPolynomial{T}) where {T<:Number}
@@ -42,11 +43,11 @@ function zero(a::HomogeneousPolynomial{T}) where {T<:Number}
     return HomogeneousPolynomial(v, a.order)
 end
 
-function zeros(::HomogeneousPolynomial{T}, order::Int) where {T<:Number}
-    order == 0 && return [HomogeneousPolynomial([zero(T)], 0)]
+function zeros(a::HomogeneousPolynomial{T}, order::Int) where {T<:Number}
+    order == 0 && return [HomogeneousPolynomial([zero(a[1])], 0)]
     v = Array{HomogeneousPolynomial{T}}(undef, order+1)
     @simd for ord in eachindex(v)
-        @inbounds v[ord] = HomogeneousPolynomial([zero(T)], ord-1)
+        @inbounds v[ord] = HomogeneousPolynomial([zero(a[1])], ord-1)
     end
     return v
 end
@@ -278,9 +279,9 @@ function *(a::HomogeneousPolynomial{T}, b::HomogeneousPolynomial{T}) where
 
     order = a.order + b.order
 
-    order > get_order() && return HomogeneousPolynomial(zero(T), get_order())
+    order > get_order() && return HomogeneousPolynomial(zero(a[1]), get_order())
 
-    res = HomogeneousPolynomial(zero(T), order)
+    res = HomogeneousPolynomial(zero(a[1]), order)
     mul!(res, a, b)
     return res
 end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -51,7 +51,7 @@ function zeros(a::HomogeneousPolynomial{T}, order::Int) where {T<:Number}
     order == 0 && return [HomogeneousPolynomial([zero(a[1])], 0)]
     v = Array{HomogeneousPolynomial{T}}(undef, order+1)
     @simd for ord in eachindex(v)
-        @inbounds v[ord] = HomogeneousPolynomial([zero(a[1])], ord-1)
+        @inbounds v[ord] = HomogeneousPolynomial(zero(a[1]), ord-1)
     end
     return v
 end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -34,8 +34,12 @@ end
 
 ## zero and one ##
 for T in (:Taylor1, :TaylorN)
-    @eval one(a::$T) = $T(one(a[0]), a.order)
     @eval zero(a::$T) = $T(zero.(a.coeffs))
+    @eval function one(a::$T)
+        b = zero(a)
+        b[0] = one(b[0])
+        return b
+    end
 end
 
 function zero(a::HomogeneousPolynomial{T}) where {T<:Number}

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -126,7 +126,7 @@ function derivative(a::HomogeneousPolynomial, r::Int)
     @assert 1 ≤ r ≤ get_numvars()
     # @show zero(a[1]) zero(eltype(a))
     T = eltype(a)
-    a.order == 0 && return HomogeneousPolynomial([zero(a[1])], 0)
+    a.order == 0 && return HomogeneousPolynomial(zero(a[1]), 0)
     @inbounds num_coeffs = size_table[a.order]
     coeffs = zeros(T,num_coeffs)
     @inbounds posTb = pos_table[a.order]

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -124,8 +124,9 @@ to the `r`-th variable.
 """
 function derivative(a::HomogeneousPolynomial, r::Int)
     @assert 1 ≤ r ≤ get_numvars()
+    # @show zero(a[1]) zero(eltype(a))
     T = eltype(a)
-    a.order == 0 && return HomogeneousPolynomial([zero(T)], 0)
+    a.order == 0 && return HomogeneousPolynomial([zero(a[1])], 0)
     @inbounds num_coeffs = size_table[a.order]
     coeffs = zeros(T,num_coeffs)
     @inbounds posTb = pos_table[a.order]
@@ -354,12 +355,12 @@ function integrate(a::HomogeneousPolynomial, r::Int)
     @assert 1 ≤ r ≤ get_numvars()
 
     order_max = get_order()
-    T = promote_type(eltype(a), eltype(a[1]/1))
-    a.order == order_max && return HomogeneousPolynomial(zero(T), 0)
+    a.order == order_max && return HomogeneousPolynomial(zero(a[1]/1), 0)
 
     @inbounds posTb = pos_table[a.order+2]
     @inbounds num_coeffs = size_table[a.order+1]
 
+    T = promote_type(eltype(a), eltype(a[1]/1))
     coeffs = zeros(T, size_table[a.order+2])
 
     @inbounds for i = 1:num_coeffs
@@ -373,7 +374,7 @@ function integrate(a::HomogeneousPolynomial, r::Int)
         iind[r] -= 1
     end
 
-    return HomogeneousPolynomial{T}(coeffs, a.order+1)
+    return HomogeneousPolynomial(coeffs, a.order+1)
 end
 integrate(a::HomogeneousPolynomial, s::Symbol) = integrate(a, lookupvar(s))
 

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -172,7 +172,6 @@ function _evaluate(a::HomogeneousPolynomial{T}, vals::NTuple{N,S} ) where
         {T<:Number, S<:Number, N}
 
     ct = coeff_table[a.order+1]
-    R = promote_type(T,S)
     suma = zero(a[1])*vals[1]
 
     for (i,a_coeff) in enumerate(a.coeffs)
@@ -247,7 +246,7 @@ function _evaluate(a::TaylorN{T}, vals::NTuple, ::Val{false}) where {T<:Number}
 end
 
 function evaluate(a::TaylorN{T}, vals::NTuple{N,Taylor1{S}}) where
-        {T<:Number, S<:NumberNotSeries, N}
+        {T<:NumberNotSeries, S<:NumberNotSeries, N}
 
     @assert N == get_numvars()
 
@@ -288,8 +287,7 @@ function evaluate(a::TaylorN{T}, vals::NTuple{N, TaylorN{S}}) where
 
     @assert length(vals) == get_numvars()
 
-    R = promote_type(T,eltype(S))
-    suma = zero(TaylorN{R})
+    suma = zero(constant_term(a))*vals[1]
 
     for homPol in length(a):-1:1
         suma += evaluate(a.coeffs[homPol], vals)

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -246,7 +246,7 @@ function _evaluate(a::TaylorN{T}, vals::NTuple, ::Val{false}) where {T<:Number}
 end
 
 function evaluate(a::TaylorN{T}, vals::NTuple{N,Taylor1{S}}) where
-        {T<:NumberNotSeries, S<:NumberNotSeries, N}
+        {T<:Number, S<:NumberNotSeries, N}
 
     @assert N == get_numvars()
 

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -41,7 +41,7 @@ is equivalent to `evaluate(x)`.
 evaluate(x::AbstractArray{Taylor1{T}}, δt::S) where
     {T<:Number, S<:Number} = evaluate.(x, δt)
 evaluate(a::AbstractArray{Taylor1{T}}) where {T<:Number} =
-    evaluate.(a, zero(T))
+    evaluate.(a)
 
 """
     evaluate!(x, δt, x0)
@@ -173,7 +173,7 @@ function _evaluate(a::HomogeneousPolynomial{T}, vals::NTuple{N,S} ) where
 
     ct = coeff_table[a.order+1]
     R = promote_type(T,S)
-    suma = zero(R)
+    suma = zero(a[1])*vals[1]
 
     for (i,a_coeff) in enumerate(a.coeffs)
         iszero(a_coeff) && continue

--- a/src/power.jl
+++ b/src/power.jl
@@ -167,7 +167,7 @@ exploits `k_0`, the order of the first non-zero coefficient of `a`.
     end
 
     # The first non-zero coefficient of the result; must be integer
-    !isinteger(r*l0) && throw(DomainError(a, 
+    !isinteger(r*l0) && throw(DomainError(a,
         """The 0th order Taylor1 coefficient must be non-zero
         to raise the Taylor1 polynomial to a non-integer exponent."""))
     lnull = trunc(Int, r*l0 )
@@ -251,9 +251,9 @@ end
 
 function square(a::HomogeneousPolynomial)
     order = 2*a.order
-    order > get_order() && return HomogeneousPolynomial([zero(a[1])], get_order())
+    order > get_order() && return HomogeneousPolynomial(zero(a[1]), get_order())
 
-    res = HomogeneousPolynomial([zero(a[1])], order)
+    res = HomogeneousPolynomial(zero(a[1]), order)
     sqr!(res, a)
     return res
 end
@@ -375,7 +375,7 @@ end
 function sqrt(a::TaylorN)
     @inbounds p0 = sqrt( constant_term(a) )
     if iszero(p0)
-        throw(DomainError(a, 
+        throw(DomainError(a,
         """The 0-th order TaylorN coefficient must be non-zero
         in order to expand `sqrt` around 0."""))
     end

--- a/src/power.jl
+++ b/src/power.jl
@@ -15,8 +15,8 @@ function ^(a::HomogeneousPolynomial, n::Integer)
     return power_by_squaring(a, n)
 end
 
-#= The following method computes `a^float(n)` (except for cases like 
-Taylor1{Interval{T}}^n, where `power_by_squaring` is used), to 
+#= The following method computes `a^float(n)` (except for cases like
+Taylor1{Interval{T}}^n, where `power_by_squaring` is used), to
 use internally `pow!`.
 =#
 ^(a::Taylor1, n::Integer) = a^float(n)
@@ -250,12 +250,10 @@ for T in (:Taylor1, :TaylorN)
 end
 
 function square(a::HomogeneousPolynomial)
-    T = eltype(a)
-
     order = 2*a.order
-    order > get_order() && return HomogeneousPolynomial([zero(T)], get_order())
+    order > get_order() && return HomogeneousPolynomial([zero(a[1])], get_order())
 
-    res = HomogeneousPolynomial([zero(T)], order)
+    res = HomogeneousPolynomial([zero(a[1])], order)
     sqr!(res, a)
     return res
 end

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -124,7 +124,7 @@ end
 function homogPol2str(a::HomogeneousPolynomial{T}) where {T<:Number}
     numVars = get_numvars()
     order = a.order
-    z = zero(T)
+    z = zero(a.coeffs[1])
     space = string(" ")
     strout::String = space
     ifirst = true

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -76,10 +76,14 @@ using LinearAlgebra, SparseArrays
     @test tN1+t == t+tN1
     @test tN1-t == -t+tN1
     zeroN1 = zero(tN1)
+    oneN1 = one(tN1)
     @test tN1-tN1 == zeroN1
     @test zero(zeroN1) == zeroN1
+    @test zeroN1 == zero.(tN1)
+    @test oneN1[0] == one(tN1[0])
+    @test oneN1[1:end] == zero.(tN1[1:end])
     for i in eachindex(tN1.coeffs)
-        @test tN1.coeffs[i].order == zeroN1.coeffs[i].order
+        @test tN1.coeffs[i].order == zeroN1.coeffs[i].order == oneN1.coeffs[i].order
     end
     @test string(t1N*t1N) ==
         "  1.0 x₁² + 𝒪(‖x‖³) + ( 2.0 x₁ + 𝒪(‖x‖³)) t + ( 1.0 + 𝒪(‖x‖³)) t² + ( 2.0 x₂² + 𝒪(‖x‖³)) t³ + 𝒪(t⁴)"

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -75,7 +75,12 @@ using LinearAlgebra, SparseArrays
     @test tN1+1im*tN1 == complex(1,1)*tN1
     @test tN1+t == t+tN1
     @test tN1-t == -t+tN1
-    @test tN1-tN1 == zero(tN1)
+    zeroN1 = zero(tN1)
+    @test tN1-tN1 == zeroN1
+    @test zero(zeroN1) == zeroN1
+    for i in eachindex(tN1.coeffs)
+        @test tN1.coeffs[i].order == zeroN1.coeffs[i].order
+    end
     @test string(t1N*t1N) ==
         "  1.0 x₁² + 𝒪(‖x‖³) + ( 2.0 x₁ + 𝒪(‖x‖³)) t + ( 1.0 + 𝒪(‖x‖³)) t² + ( 2.0 x₂² + 𝒪(‖x‖³)) t³ + 𝒪(t⁴)"
     @test !isnan(tN1)


### PR DESCRIPTION
When `t` is a `TaylorN{Taylor1}}`, `zero(t)` does not preserve the order of the coefficients of `t`, which are themselves `Taylor1`s. This PR attempts to fix this and adds corresponding tests. Example:

```julia
t = Taylor1(3)
xHt = HomogeneousPolynomial([one(t), zero(t)])
yHt = HomogeneousPolynomial([zero(t), t])
tN1 = TaylorN([HomogeneousPolynomial([t]), xHt, yHt^2])
zero(tN1).coeffs # the order of each coefficient (Taylor1) should be 3, but it's 1
```

@lbenet: do you think similar changes should be made for `one`?