### PR TITLE
Fix lu deprecation warning on julia v1.7+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -17,7 +17,6 @@ see also [`HomogeneousPolynomial`](@ref).
 module TaylorSeries
 
 
-using InteractiveUtils: subtypes
 using SparseArrays: SparseMatrixCSC
 using Markdown
 using Requires
@@ -25,6 +24,10 @@ using Requires
 using LinearAlgebra: norm, mul!,
     lu, lu!, LinearAlgebra.lutype, LinearAlgebra.copy_oftype,
     LinearAlgebra.issuccess
+
+if VERSION >= v"1.7.0-DEV.1188"
+    using LinearAlgebra: NoPivot, RowMaximum
+end
 
 import LinearAlgebra: norm, mul!, lu
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -602,6 +602,10 @@ end
 #     return Ai
 # end
 
+# see https://github.com/JuliaLang/julia/pull/40623
+const LU_RowMaximum = VERSION >= v"1.7.0-DEV.1188" ? RowMaximum() : Val(true)
+const LU_NoPivot = VERSION >= v"1.7.0-DEV.1188" ? NoPivot() : Val(false)
+
 # Adapted from (Julia v1.2) stdlib/v1.2/LinearAlgebra/src/lu.jl#240-253
 # and (Julia v1.4.0-dev) stdlib/LinearAlgebra/v1.4/src/lu.jl#270-274,
 # licensed under MIT "Expat".
@@ -610,10 +614,10 @@ end
 # We can't assume an ordered field so we first try without pivoting
 function lu(A::AbstractMatrix{Taylor1{T}}; check::Bool = true) where {T<:Number}
     S = Taylor1{lutype(T)}
-    F = lu!(copy_oftype(A, S), Val(false); check = false)
+    F = lu!(copy_oftype(A, S), LU_NoPivot; check = false)
     if issuccess(F)
         return F
     else
-        return lu!(copy_oftype(A, S), Val(true); check = check)
+        return lu!(copy_oftype(A, S), LU_RowMaximum; check = check)
     end
 end


### PR DESCRIPTION
I'm not sure why you had the InteractiveUtils `subtype` method imported. I found no use of it in the package, so I removed that dependency. I also bumped the patch version. If you don't like any of those "extra" edits, no problem, I'll revert them if preferred.