### PR TITLE
Fix abs2 and abs function for Taylor{Complex{T}}

### DIFF
--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -90,6 +90,10 @@ for T in (:Taylor1, :TaylorN)
         end
 
         abs2(a::$T) = a^2
+        
+        abs2(x::$T{T}) where {T<:Complex} = real(x)*real(x) + imag(x)*imag(x)
+
+        abs(x::$T{T}) where {T<:Complex} = sqrt(abs2(x))
     end
 end
 
@@ -128,6 +132,12 @@ function abs(a::Taylor1{TaylorN{T}}) where {T<:Real}
         (abs(x) is not differentiable at x=0)."""))
     end
 end
+
+abs2(x::Taylor1{TaylorN{T}}) where {T<:Complex} = real(x)*real(x) + imag(x)*imag(x)
+abs2(x::TaylorN{Taylor1{T}}) where {T<:Complex} = real(x)*real(x) + imag(x)*imag(x)
+
+abs(x::Taylor1{TaylorN{T}}) where {T<:Complex} = sqrt(abs2(x))
+abs(x::TaylorN{Taylor1{T}}) where {T<:Complex} = sqrt(abs2(x))
 
 @doc doc"""
     abs(a)

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -89,10 +89,8 @@ for T in (:Taylor1, :TaylorN)
             end
         end
 
-        abs2(a::$T) = a^2
-        
-        abs2(x::$T{T}) where {T<:Complex} = real(x)*real(x) + imag(x)*imag(x)
-
+        abs2(a::$T) = real(a)^2 + imag(a)^2
+    
         abs(x::$T{T}) where {T<:Complex} = sqrt(abs2(x))
     end
 end
@@ -133,11 +131,9 @@ function abs(a::Taylor1{TaylorN{T}}) where {T<:Real}
     end
 end
 
-abs2(x::Taylor1{TaylorN{T}}) where {T<:Complex} = real(x)*real(x) + imag(x)*imag(x)
-abs2(x::TaylorN{Taylor1{T}}) where {T<:Complex} = real(x)*real(x) + imag(x)*imag(x)
-
 abs(x::Taylor1{TaylorN{T}}) where {T<:Complex} = sqrt(abs2(x))
 abs(x::TaylorN{Taylor1{T}}) where {T<:Complex} = sqrt(abs2(x))
+abs(x::Taylor1{Taylor1{T}}) where {T<:Complex} = sqrt(abs2(x))
 
 @doc doc"""
     abs(a)

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -138,9 +138,12 @@ abs(x::Taylor1{Taylor1{T}}) where {T<:Complex} = sqrt(abs2(x))
 @doc doc"""
     abs(a)
 
-Returns `a` if `constant_term(a) > 0` and `-a` if `constant_term(a) < 0` for
+For a `Real` type returns `a` if `constant_term(a) > 0` and `-a` if `constant_term(a) < 0` for
 `a <:Union{Taylor1,TaylorN}`.
-Notice that `typeof(abs(a)) <: AbstractSeries`.
+For a `Complex` type, such as `Taylor1{ComplexF64}`, returns `sqrt(real(a)^2 + imag(a)^2)`. 
+
+Notice that `typeof(abs(a)) <: AbstractSeries` and 
+that for a `Complex` argument a `Real` type is returned (e.g. `typeof(abs(a::Taylor1{ComplexF64})) == Taylor1{Float64}`).
 
 """ abs
 

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -206,6 +206,10 @@ using LinearAlgebra
     @test (rem(1+xT,1.0))[0] == 0
     @test abs(1-xT)  == 1-xT
     @test abs(-1-xT)  == 1+xT
+    @test abs2(im*xT) == abs2(xT)
+    @test abs(im*(1+xT)) == abs(1+xT)
+    @test isapprox(abs2(exp(im*xT)), one(xT))
+    @test isapprox(abs(exp(im*xT)), one(xT))
     @test differentiate(yH,1) == differentiate(xH, :x₂)
     @test differentiate(mod2pi(2pi+yT^3),2) == derivative(yT^3, :x₂)
     @test differentiate(yT^3, :x₂) == differentiate(yT^3, (0,1))

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -346,4 +346,6 @@ end
     tti = (ti2to/to)/ti
     @test get_order(tti) == get_order(to)-1
     @test get_order(tti[0]) == get_order(ti)-1
+    @test isapprox(abs2(exp(im*to)), one(to))
+    @test isapprox(abs(exp(im*to)), one(to))
 end

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -109,6 +109,11 @@ using LinearAlgebra, SparseArrays
     @test_throws DomainError abs(tN1)
     @test_throws DomainError abs(t1N)
 
+    @test abs2(im*(tN1+1)) == (1+tN1)^2
+    @test abs2(im*(tN1-1)) == (1-tN1)^2
+    @test abs(im*(tN1+1)) == 1+tN1
+    @test abs(im*(tN1-1)) == 1-tN1
+
     @test convert(Array{Taylor1{TaylorN{Float64}},1}, [tN1, tN1]) == [t1N, t1N]
     @test convert(Array{Taylor1{TaylorN{Float64}},2}, [tN1 tN1]) == [t1N t1N]
     @test convert(Array{TaylorN{Taylor1{Float64}},1}, [t1N, t1N]) == [tN1, tN1]

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -250,6 +250,10 @@ Base.iszero(::SymbNumber) = false
     @test real(exp(tim)) == cos(t)
     @test imag(exp(tim)) == sin(t)
     @test exp(conj(tim)) == cos(t)-im*sin(t) == exp(tim')
+    @test abs2(tim) == tsquare
+    @test abs(tim) == t
+    @test isapprox(abs2(exp(tim)), ot)
+    @test isapprox(abs(exp(tim)), ot)
     @test (exp(t))^(2im) == cos(2t)+im*sin(2t)
     @test (exp(t))^Taylor1([-5.2im]) == cos(5.2t)-im*sin(5.2t)
     @test getcoeff(convert(Taylor1{Rational{Int}},cos(t)),8) == 1//factorial(8)


### PR DESCRIPTION
Implemented `abs` and `abs2` for `Taylor1{Complex}` and `TaylorN{Complex}`. Also tried to implement it for mixtures, though, since I am not that familiar with them and never really used them, I am unsure if the implementation is correct. 