### PR TITLE
Fix implementation of `tan`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
-version = "0.11.5"
+version = "0.12.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -11,7 +11,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 IntervalArithmetic = "0.15, 0.16, 0.17, 0.18, 0.19, 0.20"
-Requires = "0.5.2, 1.0, 1.1"
+Requires = "0.5.2, 1"
 julia = "1"
 
 [extras]

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -282,7 +282,7 @@ for T in (:Taylor1, :TaylorN)
         @inline function sincos!(s::$T{T}, c::$T{T}, a::$T{T}, k::Int) where {T<:Number}
             if k == 0
                 a0 = constant_term(a)
-                @inbounds s[0], c[0] = sin( a0 ), cos( a0 )
+                @inbounds s[0], c[0] = sincos( a0 )
                 return nothing
             end
 
@@ -319,9 +319,9 @@ for T in (:Taylor1, :TaylorN)
             end
 
             if $T == Taylor1
-                @inbounds c[k] = (k-1) * a[k-1] * c2[1]
+                @inbounds c[k] = k * a[k] * c2[0]
             else
-                @inbounds mul!(c[k], (k-1) * a[k-1], c2[1])
+                @inbounds mul!(c[k], k * a[k], c2[0])
             end
             @inbounds for i = 1:k-1
                 if $T == Taylor1

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -401,6 +401,8 @@ using LinearAlgebra
     @test getcoeff(txy,(8,7)) == 929569/99225
     ptxy = xT + yT + (1/3)*( xT^3 + yT^3 ) + xT^2*yT + xT*yT^2
     @test getindex(tan(TaylorN(1)+TaylorN(2)),0:4) == ptxy.coeffs[1:5]
+    @test tan(1+xT+yT) ≈ sin(1+xT+yT)/cos(1+xT+yT)
+    @test cot(1+xT+yT) ≈ 1/tan(1+xT+yT)
     @test evaluate(xH*yH, 1.0, 2.0) == (xH*yH)(1.0, 2.0) == 2.0
     @test evaluate(xH*yH, (1.0, 2.0)) == 2.0
     @test evaluate(xH*yH, [1.0, 2.0]) == 2.0

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -276,6 +276,8 @@ Base.iszero(::SymbNumber) = false
     @test getcoeff(convert(Taylor1{Rational{Int}},cos(t)),8) == 1//factorial(8)
     @test abs((tan(t))[7]- 17/315) < tol1
     @test abs((tan(t))[13]- 21844/6081075) < tol1
+    @test tan(1.3+t) ≈ sin(1.3+t)/cos(1.3+t)
+    @test cot(1.3+t) ≈ 1/tan(1.3+t)
     @test evaluate(exp(Taylor1([0,1],17)),1.0) == 1.0*eeuler
     @test evaluate(exp(Taylor1([0,1],1))) == 1.0
     @test evaluate(exp(t),t^2) == exp(t^2)


### PR DESCRIPTION
The motivation for this fix is related to some strange results reported in https://github.com/PerezHz/TaylorIntegration.jl/issues/133. After a very careful analysis made by @vram0gh, the culprit turned out to be the implementation of the `tan` function, which had a bug... Simply put, it was skipping the first term in a sum, which led to the wrong results.

This PR fixes https://github.com/PerezHz/TaylorIntegration.jl/issues/133