### PR TITLE
Fix ambiguity for `promote_rule`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -187,8 +187,6 @@ promote_rule(::Type{HomogeneousPolynomial{T}}, ::Type{S}) where
 promote_rule(::Type{TaylorN{T}}, ::Type{TaylorN{S}}) where {T<:Number,S<:Number} =
     TaylorN{promote_type(T,S)}
 
-promote_rule(::Type{TaylorN{T}}, ::Type{TaylorN{T}}) where {T<:Number} = TaylorN{T}
-
 promote_rule(::Type{TaylorN{T}}, ::Type{HomogeneousPolynomial{S}}) where
     {T<:Number,S<:Number} = TaylorN{promote_type(T,S)}
 
@@ -202,6 +200,8 @@ promote_rule(::Type{TaylorN{T}}, ::Type{S}) where {T<:Number,S<:Number} =
 # Order may matter
 promote_rule(::Type{S}, ::Type{T}) where {S<:NumberNotSeries,T<:AbstractSeries} =
     promote_rule(T,S)
+# disambiguation with Base
+promote_rule(::Type{Bool}, ::Type{T}) where {T<:AbstractSeries} = promote_rule(T, Bool)
 
 promote_rule(::Type{S}, ::Type{T}) where
     {S<:AbstractIrrational,T<:AbstractSeries} = promote_rule(T,S)


### PR DESCRIPTION
This popped up in https://github.com/JuliaLang/julia/pull/43972. It was also detectable via `Aqua.jl`. See https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/a95ca94_vs_811e534/TaylorSeries.primary.log.