### PR TITLE
Solve most issues detected by Aqua.jl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1', '1.8', 'nightly']
+        julia-version: ['1.6', '1', 'nightly']
         julia-arch: [x64]
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # # 32-bit Julia binaries are not available on macOS

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -108,8 +108,7 @@ for (f, fc) in ((:+, :(add!)), (:-, :(subst!)))
                 return $T(v, a.order)
             end
 
-            ($f)(a::$T{T}, b::S) where {T<:Number,S<:Number} =
-                $f(promote(a,b)...)
+            ($f)(a::$T{T}, b::S) where {T<:Number, S<:Number} = $f(promote(a, b)...)
 
             function $f(a::$T{T}, b::T) where {T<:Number}
                 coeffs = copy(a.coeffs)
@@ -117,8 +116,7 @@ for (f, fc) in ((:+, :(add!)), (:-, :(subst!)))
                 return $T(coeffs, a.order)
             end
 
-            ($f)(b::S, a::$T{T}) where {T<:Number,S<:Number} =
-                $f(promote(b,a)...)
+            # ($f)(b::S, a::$T{T}) where {T<:Number,S<:Number} = $f(promote(b, a)...)
 
             function $f(b::T, a::$T{T}) where {T<:Number}
                 coeffs = similar(a.coeffs)
@@ -149,7 +147,11 @@ for (f, fc) in ((:+, :(add!)), (:-, :(subst!)))
                 return nothing
             end
         end
+
     end
+
+    @eval $(f)(a::T, b::S) where {T<:Taylor1, S<:TaylorN} = $(f)(promote(a, b)...)
+    @eval $(f)(a::T, b::S) where {T<:TaylorN, S<:Taylor1} = $(f)(promote(a, b)...)
 
     @eval begin
         ($f)(a::HomogeneousPolynomial{T}, b::HomogeneousPolynomial{S}) where
@@ -210,11 +212,6 @@ for (f, fc) in ((:+, :(add!)), (:-, :(subst!)))
         end
     end
 end
-
-+(a::Taylor1{T}, b::TaylorN{S}) where {T<:NumberNotSeries,S<:NumberNotSeries} =
-    +(promote(a,b)...)
--(a::Taylor1{T}, b::TaylorN{S}) where {T<:NumberNotSeries,S<:NumberNotSeries} =
-    -(promote(a,b)...)
 
 
 ## Multiplication ##

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -122,8 +122,7 @@ getcoeff(a::HomogeneousPolynomial, v::Array{Int,1}) = getcoeff(a, (v...,))
 getindex(a::HomogeneousPolynomial, n::Int) = a.coeffs[n]
 getindex(a::HomogeneousPolynomial, n::UnitRange{Int}) = view(a.coeffs, n)
 getindex(a::HomogeneousPolynomial, c::Colon) = view(a.coeffs, c)
-getindex(a::HomogeneousPolynomial, u::StepRange{Int,Int}) where {T<:Number} =
-    view(a.coeffs, u[:])
+getindex(a::HomogeneousPolynomial, u::StepRange{Int,Int}) = view(a.coeffs, u[:])
 
 setindex!(a::HomogeneousPolynomial{T}, x::T, n::Int) where {T<:Number} =
     a.coeffs[n] = x
@@ -158,8 +157,7 @@ getcoeff(a::TaylorN, v::Array{Int,1}) = getcoeff(a, (v...,))
 getindex(a::TaylorN, n::Int) = a.coeffs[n+1]
 getindex(a::TaylorN, u::UnitRange{Int}) = view(a.coeffs, u .+ 1)
 getindex(a::TaylorN, c::Colon) = view(a.coeffs, c)
-getindex(a::TaylorN, u::StepRange{Int,Int}) where {T<:Number} =
-    view(a.coeffs, u[:] .+ 1)
+getindex(a::TaylorN, u::StepRange{Int,Int}) = view(a.coeffs, u[:] .+ 1)
 
 function setindex!(a::TaylorN{T}, x::HomogeneousPolynomial{T}, n::Int) where {T<:Number}
     @assert x.order == n

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -94,7 +94,7 @@ function evaluate(a::Taylor1{T}, x::Taylor1{Taylor1{T}}) where {T<:Number}
     suma
 end
 
-evaluate(p::Taylor1{T}, x::Array{S}) where {T<:Number,S<:Number} = evaluate.(Ref(p), x)
+evaluate(p::Taylor1{T}, x::AbstractArray{S}) where {T<:Number,S<:Number} = evaluate.(Ref(p), x)
 
 
 #function-like behavior for Taylor1
@@ -154,17 +154,13 @@ Evaluate a `HomogeneousPolynomial` polynomial at `vals`. If `vals` is ommitted,
 it's evaluated at zero. Note that the syntax `a(vals)` is equivalent to
 `evaluate(a, vals)`; and `a()` is equivalent to `evaluate(a)`.
 """
-function evaluate(a::HomogeneousPolynomial{T}, vals::NTuple{N,S} ) where
-        {T<:Number,S<:Number,N}
-
-    @assert N == get_numvars()
+function evaluate(a::HomogeneousPolynomial, vals::NTuple)
+    @assert length(vals) == get_numvars()
 
     return _evaluate(a, vals)
 end
 
-function _evaluate(a::HomogeneousPolynomial{T}, vals::NTuple{N,S} ) where
-        {T<:Number,S<:Number,N}
-
+function _evaluate(a::HomogeneousPolynomial, vals::NTuple)
     ct = coeff_table[a.order+1]
     suma = zero(a[1])*vals[1]
 
@@ -178,12 +174,12 @@ function _evaluate(a::HomogeneousPolynomial{T}, vals::NTuple{N,S} ) where
 end
 
 
-evaluate(a::HomogeneousPolynomial{T}, vals::Array{S,1} ) where
+evaluate(a::HomogeneousPolynomial{T}, vals::AbstractArray{S,1} ) where
         {T<:Number,S<:NumberNotSeriesN} = _evaluate(a, (vals...,))
 
-evaluate(a::HomogeneousPolynomial{T}, v, vals::Vararg{S,N}) where {T,S,N} = evaluate(a, (v, vals...,))
+evaluate(a::HomogeneousPolynomial, v, vals::Vararg) = evaluate(a, (v, vals...,))
 
-evaluate(a::HomogeneousPolynomial{T}, v) where {T<:Number} = evaluate(a, [v...])
+evaluate(a::HomogeneousPolynomial, v) = evaluate(a, [v...])
 
 function evaluate(a::HomogeneousPolynomial)
     a.order == 0 && return a[1]
@@ -229,8 +225,6 @@ evaluate(a::TaylorN{Taylor1}, vals::NTuple; sorting::Bool=false) =
 
 evaluate(a::TaylorN{Taylor1}, v::Number, vals::Vararg; sorting::Bool=false) =
     _evaluate(a, (v, vals...,), Val(sorting))
-
-# evaluate(a::TaylorN, vals::AbstractVector{Number}) = evaluate(a, (vals...,))
 
 evaluate(a::TaylorN, vals::AbstractVector{T}) where {S, T<:AbstractSeries{S}} =
     _evaluate(a, (vals...,), Val(false))

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -83,14 +83,14 @@ for T in (:Taylor1, :TaylorN)
             elseif constant_term(a) < 0
                 return -a
             else
-                throw(DomainError(a, 
+                throw(DomainError(a,
                 """The 0th order Taylor1 coefficient must be non-zero
                 (abs(x) is not differentiable at x=0)."""))
             end
         end
 
         abs2(a::$T) = real(a)^2 + imag(a)^2
-    
+
         abs(x::$T{T}) where {T<:Complex} = sqrt(abs2(x))
     end
 end
@@ -140,9 +140,9 @@ abs(x::Taylor1{Taylor1{T}}) where {T<:Complex} = sqrt(abs2(x))
 
 For a `Real` type returns `a` if `constant_term(a) > 0` and `-a` if `constant_term(a) < 0` for
 `a <:Union{Taylor1,TaylorN}`.
-For a `Complex` type, such as `Taylor1{ComplexF64}`, returns `sqrt(real(a)^2 + imag(a)^2)`. 
+For a `Complex` type, such as `Taylor1{ComplexF64}`, returns `sqrt(real(a)^2 + imag(a)^2)`.
 
-Notice that `typeof(abs(a)) <: AbstractSeries` and 
+Notice that `typeof(abs(a)) <: AbstractSeries` and
 that for a `Complex` argument a `Real` type is returned (e.g. `typeof(abs(a::Taylor1{ComplexF64})) == Taylor1{Float64}`).
 
 """ abs
@@ -215,18 +215,18 @@ a `TaylorN` expansion will be computed. If the dimension of x0 (`length(x0)`)
 is different from the variables set for `TaylorN` (`get_numvars()`), an
 `AssertionError` will be thrown.
 """
-function taylor_expand(f::F; order::Int=15) where {F}
+function taylor_expand(f::Function; order::Int=15)
    a = Taylor1(order)
    return f(a)
 end
 
-function taylor_expand(f::F, x0::T; order::Int=15) where {F,T<:Number}
+function taylor_expand(f::Function, x0::T; order::Int=15) where {T<:Number}
    a = Taylor1([x0, one(T)], order)
    return f(a)
 end
 
 #taylor_expand function for TaylorN
-function taylor_expand(f::F, x0::Vector{T}; order::Int=get_order()) where {F,T<:Number}
+function taylor_expand(f::Function, x0::Vector{T}; order::Int=get_order()) where {T<:Number}
     ll = length(x0)
     @assert ll == get_numvars() && order <= get_order()
     X = Array{TaylorN{T}}(undef, ll)
@@ -238,9 +238,10 @@ function taylor_expand(f::F, x0::Vector{T}; order::Int=get_order()) where {F,T<:
     return f( X )
 end
 
-function taylor_expand(f::F, x0::Vararg{T, N}; order::Int=get_order()) where {F,T,N}
+function taylor_expand(f::Function, x0::Vararg; order::Int=get_order())
     x0 = promote(x0...)
     ll = length(x0)
+    T = eltype(x0[1])
     @assert ll == get_numvars() && order <= get_order()
     X = Array{TaylorN{T}}(undef, ll)
 


### PR DESCRIPTION
This is a follow up of #298, where it was mentioned that some ambiguities were detected by [`Aqua.jl`](https://github.com/JuliaTesting/Aqua.jl). This PR solves all ambiguities, but leaves some unbound type parameters (`unbound_args`) unsolved. 

Using it, I get the following:
```julia
julia> using TaylorSeries

julia> using Aqua

julia> Aqua.test_all(TaylorSeries; unbound_args=false)
Skipping Base.active_repl
Skipping Base.active_repl_backend
Skipping Base.Filesystem.JL_O_RANDOM
Skipping Base.Filesystem.JL_O_SEQUENTIAL
Skipping Base.Filesystem.JL_O_SHORT_LIVED
Skipping Base.Filesystem.JL_O_TEMPORARY
Skipping Base.BinaryPlatforms.compiler_abi
Skipping Base.active_repl
Skipping Base.active_repl_backend
Skipping Base.Filesystem.JL_O_RANDOM
Skipping Base.Filesystem.JL_O_SEQUENTIAL
Skipping Base.Filesystem.JL_O_SHORT_LIVED
Skipping Base.Filesystem.JL_O_TEMPORARY
Skipping Base.BinaryPlatforms.compiler_abi
Test Summary:    | Pass  Total
Method ambiguity |    1      1
Test Summary:           |
Unbound type parameters | No tests
Test Summary:     | Pass  Total
Undefined exports |    1      1
Test Summary:                              | Pass  Total
Compare Project.toml and test/Project.toml |    1      1
Test Summary:      | Pass  Total
Stale dependencies |    1      1
Test Summary: | Pass  Total
Compat bounds |    1      1
Test Summary:           | Pass  Total
Project.toml formatting |    1      1
Test.DefaultTestSet("Project.toml formatting", Any[Test.DefaultTestSet("/Users/benet/.julia/dev/TaylorSeries/Project.toml", Any[], 1, false, false)], 0, false, false)
```

The failing test yields:
```julia
julia> Aqua.test_unbound_args(TaylorSeries)
Test Failed at /Users/benet/.julia/packages/Aqua/DaPBP/src/unbound_args.jl:10
  Expression: detect_unbound_args_recursively(m) == []
   Evaluated: Any[
(::TaylorSeries.var"#evaluate##kw")(::Any, ::typeof(evaluate), a::TaylorN, vals::Tuple{Vararg{T, N}}) where {N, T<:AbstractSeries} in TaylorSeries at /Users/benet/.julia/dev/TaylorSeries/src/evaluate.jl:218, 
var"#evaluate#44"(sorting::Bool, ::typeof(evaluate), a::TaylorN, vals::Tuple{Vararg{T, N}}) where {N, T<:AbstractSeries} in TaylorSeries at /Users/benet/.julia/dev/TaylorSeries/src/evaluate.jl:218, 
evaluate(a::TaylorN, vals::Tuple{Vararg{T, N}}; sorting) where {N, T<:AbstractSeries} in TaylorSeries at /Users/benet/.julia/dev/TaylorSeries/src/evaluate.jl:218] == Any[]
```
All reported cases are related to `NTuple{N,T}` with `N` left unspecified.