### PR TITLE
Support `<` and `>`  through `isless`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
-version = "0.14.0"
+version = "0.15.0"
 
 [deps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -50,6 +50,7 @@ inverse
 abs
 norm
 isapprox
+isless
 isfinite
 displayBigO
 use_show_default

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -360,7 +360,7 @@ x, y = set_variables("x y", order=10);
 
 show_monomials(2)
 ```
-Then, the following clearly holds:
+Then, the following then holds:
 ```@repl userguide
 0 < 1e8 * y^2 < x*y < x^2  < y < x/1e8 < 1.0
 ```

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -352,12 +352,23 @@ The ordering is consistent with the interpretation that there are infinitessimal
 elements in the algebra; for details see M. Berz, "Automatic Differentiation as
 Nonarchimedean Analysis", Computer Arithmetic and Enclosure Methods, (1992), Elsevier,
 439-450.
+Essentially, the lexicographic order works as follows: smaller order monomials
+are *larger* than higher order monomials; when the order is the same, *larger* monomials
+appear before in the hash-tables; the function [`show_monomials`](@ref).
+```@repl userguide
+x, y = set_variables("x y", order=10);
+
+show_monomials(2)
+```
+Then, the following clearly holds:
+```@repl userguide
+0 < 1e8 * y^2 < x*y < x^2  < y < x/1e8 < 1.0
+```
 
 The elementary functions have also been
 implemented, again by computing their coefficients recursively:
 
 ```@repl userguide
-x, y = set_variables("x y", order=10);
 exy = exp(x+y)
 ```
 

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -105,6 +105,16 @@ of order 5; this is be consistent with the number of known coefficients of the
 returned series, since the result corresponds to factorize `t` in the numerator
 to cancel the same factor in the denominator.
 
+`Taylor1` is also equiped with a total order, provided by overloading [`isless`](@ref).
+The ordering is consistent with the interpretation that there are infinitessimal
+elements in the algebra; for details see M. Berz, "Automatic Differentiation as
+Nonarchimedean Analysis", Computer Arithmetic and Enclosure Methods, (1992), Elsevier,
+439-450. This is illustrated by:
+
+```@repl userguide
+1 > t > 2*t^2 > 100*t^3 >= 0
+```
+
 If no valid Taylor expansion can be computed an error is thrown, for instance,
 when a derivative is not defined at the expansion point, or it simply diverges.
 
@@ -336,6 +346,12 @@ Note that some of the arithmetic operations have been extended for
 [`HomogeneousPolynomial`](@ref); division, for instance, is not extended.
 The same convention used for `Taylor1` objects is used when combining
 `TaylorN` polynomials of different order.
+Both `HomogeneousPolynomial` and `TaylorN` are equiped with a total *lexicographical*
+order, provided by overloading [`isless`](@ref).
+The ordering is consistent with the interpretation that there are infinitessimal
+elements in the algebra; for details see M. Berz, "Automatic Differentiation as
+Nonarchimedean Analysis", Computer Arithmetic and Enclosure Methods, (1992), Elsevier,
+439-450.
 
 The elementary functions have also been
 implemented, again by computing their coefficients recursively:

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -31,7 +31,7 @@ end
 
 import LinearAlgebra: norm, mul!, lu
 
-import Base: ==, +, -, *, /, ^
+import Base: ==, +, -, *, /, ^, <, >
 
 import Base: iterate, size, eachindex, firstindex, lastindex,
     eltype, length, getindex, setindex!, axes, copyto!

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -31,12 +31,12 @@ end
 
 import LinearAlgebra: norm, mul!, lu
 
-import Base: ==, +, -, *, /, ^, <, >
+import Base: ==, +, -, *, /, ^
 
 import Base: iterate, size, eachindex, firstindex, lastindex,
     eltype, length, getindex, setindex!, axes, copyto!
 
-import Base: zero, one, zeros, ones, isinf, isnan, iszero,
+import Base: zero, one, zeros, ones, isinf, isnan, iszero, isless,
     convert, promote_rule, promote, show,
     real, imag, conj, adjoint,
     rem, mod, mod2pi, abs, abs2,

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -112,7 +112,7 @@ end
 end
 @inline isless(a::TaylorN{Taylor1{T}}, b::TaylorN{Taylor1{T}}) where {T<:NumberNotSeries} = isless(a - b, zero(T))
 
-#= TODO: Nested Taylor1s; needs careful thinking. The following works:
+#= TODO: Nested Taylor1s; needs careful thinking; iss #326. The following works:
 @inline isless(a::Taylor1{Taylor1{T}}, b::Taylor1{Taylor1{T}}) where {T<:Number} = isless(a - b, zero(T))
 # Is the following correct?
 # ti = Taylor1(3)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -33,14 +33,66 @@ function ==(a::HomogeneousPolynomial, b::HomogeneousPolynomial)
     return iszero(a.coeffs) && iszero(b.coeffs)
 end
 
-# Iss: #209
-"""
+## Total ordering ##
+for (fn, gn) in zip((:<,:>), (:>,:<))
+    for T in (:Taylor1, :TaylorN)
+        @eval begin
+            function $fn(a::$T{<:Real}, b::Real)
+                a0 = constant_term(a)
+                a0 != b && return $fn(a0, b)
+                nz = findfirst(a-b)
+                if nz == -1
+                    return $fn(zero(a0), zero(b))
+                else
+                    return $fn(a[nz], zero(b))
+                end
+            end
+            $fn(b::Real, a::$T{<:Real}) = $gn(a, b)
+            #
+            $fn(a::$T{T}, b::$T{S}) where {T<:Number, S<:Number} = $fn(promote(a,b)...)
+            $fn(a::$T{T}, b::$T{T}) where {T<:Number} = $fn(a - b, zero(constant_term(a)))
+        end
+    end
+
+    @eval begin
+        function $fn(a::HomogeneousPolynomial{<:Real}, b::Real)
+            orda = get_order(a)
+            if orda == 0
+                return $fn(a[1], b)
+            else
+                !iszero(b) && return zero($fn(a[1]), b)
+                nz = findfirst(a)
+                return $fn(a[nz], zero(b))
+            end
+        end
+        $fn(b::Real, a::HomogeneousPolynomial{<:Real}) = $gn(a, b)
+        #
+        $fn(a::HomogeneousPolynomial{T}, b::HomogeneousPolynomial{S}) where {T<:Number,S<:Number} = $fn(promote(a,b)...)
+        function $fn(a::HomogeneousPolynomial{T}, b::HomogeneousPolynomial{T}) where {T<:Number}
+            orda = get_order(a)
+            ordb = get_order(b)
+            if orda == ordb
+                return $fn(a-b, zero(a[1]))
+            elseif orda < ordb
+                return $fn(a, zero(a[1]))
+            else
+                return $fn(-b, zero(a[1]))
+            end
+        end
+    end
+end
+
+@doc doc"""
     <(a::Taylor1{<:Real}, b::Real)
     <(a::TaylorN{<:Real}, b::Real)
 
 Less-than comparison of `a::Taylor1` series and `b::Real`, computed by comparing
 `constant_term(a)` and `b`. If they are equal, returns `a[nz] < 0`, with `nz` the first
 non-zero coefficient beyond the constant term. This defines a total order.
+
+For many variables, the ordering must include a lexicographical convention in order to be
+total. We have opted for the simplest, where the *larger* variable appears *before*
+when they are defined (e.g., through [`set_variables`](@ref)).
 
 Refs:
 - M. Berz, AIP Conference Proceedings 177, 275 (1988); https://doi.org/10.1063/1.37800
@@ -53,51 +105,19 @@ Refs:
     <(a::TaylorN{<:Real}, b::Taylor1{<:Real})
 
 Return `a - b < zero(b)`.
-"""
-function <(a::Taylor1{<:Real}, b::Real)
-    a0 = constant_term(a)
-    a0 != b && return a0 < b
-    nz = findfirst(a-b)
-    if nz == -1
-        return zero(a0) < zero(b)
-    else
-        return a[nz] < zero(b)
-    end
-end
-<(b::Real, a::Taylor1{<:Real}) = >(a, b)
+""" :<
 
-function <(a::HomogeneousPolynomial{<:Real}, b::Real)
-    ord_a = get_order(a)
-    if ord_a == 0
-        return a[1] < b
-    else
-        !iszero(b) && return zero(a[1]) < b
-        nz = findfirst(a)
-        return a[nz] < zero(b)
-    end
-end
-<(b::Real, a::HomogeneousPolynomial{<:Real}) = >(a, b)
-
-function <(a::TaylorN{<:Real}, b::Real)
-    a0 = constant_term(a)
-    a0 != b && return a0 < b
-    nz = findfirst(a-b)
-    if nz == -1
-        return zero(a0) < zero(b)
-    else
-        return a[nz] < zero(b)
-    end
-end
-<(b::Real, a::TaylorN{<:Real}) = >(a, b)
-
-
-"""
+@doc doc"""
     >(a::Taylor1{<:Real}, b::Real)
-    >(a::Taylor1{<:Real}, b::Real)
+    >(a::TaylorN{<:Real}, b::Real)
 
-Greater-than comparison of `a::Taylor1` series and `b::Real`, computed by comparing
+Greater-than comparison of `a` series and `b::Real`, computed by comparing
 `constant_term(a)` and `b`. If both are equal, returns `a[nz] > 0`, with `nz` the first
 non-zero coefficient beyond the constant term. This defines a total order.
+
+For many variables, the ordering must include a lexicographical convention in order to be
+total. We have opted for the simplest, where the *larger* variable appears *before*
+when they are defined (e.g., through [`set_variables`](@ref)).
 
 Refs:
 - M. Berz, AIP Conference Proceedings 177, 275 (1988); https://doi.org/10.1063/1.37800
@@ -110,73 +130,14 @@ Refs:
 >(a::TaylorN{<:Real}, b::Taylor1{<:Real})
 
 Return `a - b > zero(b)`.
-"""
-function >(a::Taylor1{<:Real}, b::Real)
-    a0 = constant_term(a)
-    a0 != b && return a0 > b
-    nz = findfirst(a-b)
-    if nz == -1
-        return zero(a0) > zero(b)
-    else
-        return a[nz] > zero(b)
-    end
-end
->(b::Real, a::Taylor1{<:Real}) = <(a, b)
-
-function >(a::HomogeneousPolynomial{<:Real}, b::Real)
-    ord_a = get_order(a)
-    if ord_a == 0
-        return a[1] > b
-    else
-        !iszero(b) && return zero(a[1]) > b
-        nz = findfirst(a)
-        return a[nz] > zero(b)
-    end
-end
->(b::Real, a::HomogeneousPolynomial{<:Real}) = <(a, b)
-
-function >(a::TaylorN{<:Real}, b::Real)
-    a0 = constant_term(a)
-    a0 != b && return a0 > b
-    nz = findfirst(a-b)
-    if nz == -1
-        return zero(a0) > zero(b)
-    else
-        return a[nz] > zero(b)
-    end
-end
->(b::Real, a::TaylorN{<:Real}) = <(a, b)
-
-#
-for T in (:Taylor1, :TaylorN,)
-    @eval begin
-        <(a::$T{T}, b::$T{S}) where {T<:Number,S<:Number} = <(promote(a,b)...)
-        <(a::$T{T}, b::$T{T}) where {T<:Number} = a - b < zero(constant_term(a))
-
-        >(a::$T{T}, b::$T{S}) where {T<:Number,S<:Number} = >(promote(a,b)...)
-        >(a::$T{T}, b::$T{T}) where {T<:Number} = a - b > zero(constant_term(a))
-    end
-end
-
-<(a::HomogeneousPolynomial{T}, b::HomogeneousPolynomial{S}) where {T<:Number,S<:Number} = <(promote(a,b)...)
-function <(a::HomogeneousPolynomial{T}, b::HomogeneousPolynomial{T}) where {T<:Number}
-    ord_a = get_order(a)
-    ord_b = get_order(b)
-    if ord_a == ord_b
-        return a-b < zero(a[1])
-    elseif ord_a < ord_b
-        return a < zero(a[1])
-    else
-        return -b < zero(a[1])
-    end
-end
+""" :>
 
 
+## zero and one ##
 for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
     @eval iszero(a::$T) = iszero(a.coeffs)
 end
 
-## zero and one ##
 for T in (:Taylor1, :TaylorN)
     @eval zero(a::$T) = $T(zero.(a.coeffs))
     @eval function one(a::$T)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -96,6 +96,33 @@ end
     end
 end
 
+# Mixtures
+@inline isless(a::Taylor1{TaylorN{T}}, b::Taylor1{TaylorN{T}}) where {T<:NumberNotSeries} =
+    isless(a - b, zero(T))
+@inline function isless(a::HomogeneousPolynomial{Taylor1{T}}, b::HomogeneousPolynomial{Taylor1{T}}) where {T<:NumberNotSeries}
+    orda = get_order(a)
+    ordb = get_order(b)
+    if orda == ordb
+        return isless(a-b, zero(T))
+    elseif orda < ordb
+        return isless(a, zero(T))
+    else
+        return isless(-b, zero(T))
+    end
+end
+@inline isless(a::TaylorN{Taylor1{T}}, b::TaylorN{Taylor1{T}}) where {T<:NumberNotSeries} = isless(a - b, zero(T))
+
+#= TODO: Nested Taylor1s; needs careful thinking. The following works:
+@inline isless(a::Taylor1{Taylor1{T}}, b::Taylor1{Taylor1{T}}) where {T<:Number} = isless(a - b, zero(T))
+# Is the following correct?
+# ti = Taylor1(3)
+# to = Taylor1([zero(ti), one(ti)], 9)
+# tito = ti * to
+# ti > to > 0 # ok
+# to^2 < toti < ti^2 # ok
+# ti > ti^2 > to # is this ok?
+=#
+
 @doc doc"""
     isless(a::Taylor1{<:Real}, b::Real)
     isless(a::TaylorN{<:Real}, b::Real)

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -268,13 +268,13 @@ end
 # Finds the first non zero entry; extended to Taylor1
 function Base.findfirst(a::Taylor1{T}) where {T<:Number}
     first = findfirst(x->!iszero(x), a.coeffs)
-    isa(first, Nothing) && return -1
+    isnothing(first) && return -1
     return first-1
 end
 # Finds the last non-zero entry; extended to Taylor1
 function Base.findlast(a::Taylor1{T}) where {T<:Number}
     last = findlast(x->!iszero(x), a.coeffs)
-    isa(last, Nothing) && return -1
+    isnothing(last) && return -1
     return last-1
 end
 

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -278,6 +278,30 @@ function Base.findlast(a::Taylor1{T}) where {T<:Number}
     return last-1
 end
 
+# Finds the first non zero entry; extended to HomogeneousPolynomial
+function Base.findfirst(a::HomogeneousPolynomial{T}) where {T<:Number}
+    first = findfirst(x->!iszero(x), a.coeffs)
+    isa(first, Nothing) && return -1
+    return first
+end
+function Base.findfirst(a::TaylorN{T}) where {T<:Number}
+    first = findfirst(x->!iszero(x), a.coeffs)
+    isa(first, Nothing) && return -1
+    return first-1
+end
+# Finds the last non-zero entry; extended to HomogeneousPolynomial
+function Base.findlast(a::HomogeneousPolynomial{T}) where {T<:Number}
+    last = findlast(x->!iszero(x), a.coeffs)
+    isa(last, Nothing) && return -1
+    return last
+end
+# Finds the last non-zero entry; extended to TaylorN
+function Base.findlast(a::TaylorN{T}) where {T<:Number}
+    last = findlast(x->!iszero(x), a.coeffs)
+    isa(last, Nothing) && return -1
+    return last-1
+end
+
 
 ## copyto! ##
 # Inspired from base/abstractarray.jl, line 665

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -136,9 +136,9 @@ end
     @test HomogeneousPolynomial(0,0)  == 0
     @test (@inferred conj(xH)) == (@inferred adjoint(xH))
     @test (@inferred real(xH)) == xH
-    @test xH > yH > xH^2
+    @test HomogeneousPolynomial([2.1]) > xH > yH > xH^2
     @test -xH < -yH^2 < 0
-    @test HomogeneousPolynomial([-2]) < 0
+    @test HomogeneousPolynomial([-2.1]) < 0
     @test !(zero(yH^2) > 0)
     xT = TaylorN(xH, 17)
     yT = TaylorN(Int, 2, order=17)
@@ -231,8 +231,8 @@ end
     @test eltype(convert(TaylorN{Complex{Float64}},1)) == TaylorN{Complex{Float64}}
     @test TS.numtype(convert(TaylorN{Complex{Float64}},1)) == Complex{Float64}
     @test normalize_taylor(xT) == xT
-    @test 1 > xT > yT > xT^2 > 0
-    @test -yT < -xT^2 < 0
+    @test 1.0 > xT > yT > xT^2 > 0
+    @test -1 < -yT < -xT^2 < 0.0
     @test !(zero(xT) > 0)
     @test !(zero(yT^2) < 0)
 

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -136,9 +136,9 @@ end
     @test HomogeneousPolynomial(0,0)  == 0
     @test (@inferred conj(xH)) == (@inferred adjoint(xH))
     @test (@inferred real(xH)) == xH
-    @test HomogeneousPolynomial([2.1]) > xH > yH > xH^2
-    @test -xH < -yH^2 < 0
-    @test HomogeneousPolynomial([-2.1]) < 0
+    @test HomogeneousPolynomial([2.1]) > 0.5 * xH > yH > xH^2
+    @test -1.0*xH < -yH^2 < 0 < HomogeneousPolynomial([1.0])
+    @test -3 < HomogeneousPolynomial([-2]) < 0.0
     @test !(zero(yH^2) > 0)
     xT = TaylorN(xH, 17)
     yT = TaylorN(Int, 2, order=17)
@@ -231,8 +231,8 @@ end
     @test eltype(convert(TaylorN{Complex{Float64}},1)) == TaylorN{Complex{Float64}}
     @test TS.numtype(convert(TaylorN{Complex{Float64}},1)) == Complex{Float64}
     @test normalize_taylor(xT) == xT
-    @test 1.0 > xT > yT > xT^2 > 0
-    @test -1 < -yT < -xT^2 < 0.0
+    @test 1 > 0.5 * xT > yT > xT^2 > 0 > TaylorN(-1.0, 3)
+    @test -1 < -0.25 * yT < -xT^2 < 0.0 < TaylorN(1, 3)
     @test !(zero(xT) > 0)
     @test !(zero(yT^2) < 0)
 

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -94,6 +94,7 @@ end
     @test_throws AssertionError TS.resize_coeffsHP!(v,1)
     hpol_v = HomogeneousPolynomial(v)
     @test findfirst(hpol_v) == 1
+    @test findlast(hpol_v) == 2
     hpol_v[3] = 3
     @test v == [1,2,3]
     hpol_v[1:3] = 3
@@ -101,12 +102,14 @@ end
     hpol_v[1:2:2] = 0
     @test v == [0,3,3]
     @test findfirst(hpol_v) == 2
+    @test findlast(hpol_v) == 3
     hpol_v[1:1:2] = [1,2]
     @test all(hpol_v[1:1:2] .== [1,2])
     @test v == [1,2,3]
     hpol_v[:] = zeros(Int, 3)
     @test hpol_v == 0
     @test findfirst(hpol_v) == -1
+    @test findlast(hpol_v) == -1
 
     tn_v = TaylorN(HomogeneousPolynomial(zeros(Int, 3)))
     tn_v[0] = 1
@@ -135,13 +138,16 @@ end
     @test (@inferred real(xH)) == xH
     @test xH > yH > xH^2
     @test -xH < -yH^2 < 0
+    @test HomogeneousPolynomial([-2]) < 0
+    @test !(zero(yH^2) > 0)
     xT = TaylorN(xH, 17)
     yT = TaylorN(Int, 2, order=17)
     @test findfirst(xT) == 1
+    @test findlast(yT) == 1
     @test (@inferred conj(xT)) == (@inferred adjoint(xT))
     @test (@inferred real(xT)) == (xT)
     zeroT = zero( TaylorN([xH],1) )
-    @test findfirst(zeroT) == -1
+    @test findfirst(zeroT) == findlast(zeroT) == -1
     @test (@inferred imag(xT)) == (zeroT)
     @test zeroT.coeffs == zeros(HomogeneousPolynomial{Int}, 1)
     @test size(xH) == (2,)
@@ -227,6 +233,8 @@ end
     @test normalize_taylor(xT) == xT
     @test 1 > xT > yT > xT^2 > 0
     @test -yT < -xT^2 < 0
+    @test !(zero(xT) > 0)
+    @test !(zero(yT^2) < 0)
 
     @test 1+xT+yT == TaylorN(1,1) + TaylorN([xH,yH],1)
     @test xT-yT-1 == TaylorN([-1,xH-yH])

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -133,6 +133,8 @@ end
     @test HomogeneousPolynomial(0,0)  == 0
     @test (@inferred conj(xH)) == (@inferred adjoint(xH))
     @test (@inferred real(xH)) == xH
+    @test xH > yH
+    @test -yH < 0
     xT = TaylorN(xH, 17)
     yT = TaylorN(Int, 2, order=17)
     @test findfirst(xT) == 1
@@ -223,6 +225,8 @@ end
     @test eltype(convert(TaylorN{Complex{Float64}},1)) == TaylorN{Complex{Float64}}
     @test TS.numtype(convert(TaylorN{Complex{Float64}},1)) == Complex{Float64}
     @test normalize_taylor(xT) == xT
+    @test 1 > xT > yT > xT^2 > 0
+    @test -yT < -xT^2 < 0
 
     @test 1+xT+yT == TaylorN(1,1) + TaylorN([xH,yH],1)
     @test xT-yT-1 == TaylorN([-1,xH-yH])
@@ -766,6 +770,8 @@ end
     @test yT[0] == xT[0]*(pi/180)
     TS.rad2deg!(yT, xT, 0)
     @test yT[0] == xT[0]*(180/pi)
+    @test 1 > dx[1] > dx[2] > dx[3] > dx[4]
+    @test dx[4]^2 < dx[3]*dx[4] < dx[3]^2 < dx[2]*dx[4] < dx[2]*dx[3] < dx[2]^2 < dx[1]*dx[4] < dx[1]*dx[3] < dx[1]*dx[2] < dx[1]^2
 end
 
 @testset "Integrate for several variables" begin

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -133,8 +133,8 @@ end
     @test HomogeneousPolynomial(0,0)  == 0
     @test (@inferred conj(xH)) == (@inferred adjoint(xH))
     @test (@inferred real(xH)) == xH
-    @test xH > yH
-    @test -yH < 0
+    @test xH > yH > xH^2
+    @test -xH < -yH^2 < 0
     xT = TaylorN(xH, 17)
     yT = TaylorN(Int, 2, order=17)
     @test findfirst(xT) == 1

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -93,17 +93,20 @@ end
     @test v == [1,2,0]
     @test_throws AssertionError TS.resize_coeffsHP!(v,1)
     hpol_v = HomogeneousPolynomial(v)
+    @test findfirst(hpol_v) == 1
     hpol_v[3] = 3
     @test v == [1,2,3]
     hpol_v[1:3] = 3
     @test v == [3,3,3]
     hpol_v[1:2:2] = 0
     @test v == [0,3,3]
+    @test findfirst(hpol_v) == 2
     hpol_v[1:1:2] = [1,2]
     @test all(hpol_v[1:1:2] .== [1,2])
     @test v == [1,2,3]
     hpol_v[:] = zeros(Int, 3)
     @test hpol_v == 0
+    @test findfirst(hpol_v) == -1
 
     tn_v = TaylorN(HomogeneousPolynomial(zeros(Int, 3)))
     tn_v[0] = 1
@@ -132,9 +135,11 @@ end
     @test (@inferred real(xH)) == xH
     xT = TaylorN(xH, 17)
     yT = TaylorN(Int, 2, order=17)
+    @test findfirst(xT) == 1
     @test (@inferred conj(xT)) == (@inferred adjoint(xT))
     @test (@inferred real(xT)) == (xT)
     zeroT = zero( TaylorN([xH],1) )
+    @test findfirst(zeroT) == -1
     @test (@inferred imag(xT)) == (zeroT)
     @test zeroT.coeffs == zeros(HomogeneousPolynomial{Int}, 1)
     @test size(xH) == (2,)

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -136,10 +136,6 @@ end
     @test HomogeneousPolynomial(0,0)  == 0
     @test (@inferred conj(xH)) == (@inferred adjoint(xH))
     @test (@inferred real(xH)) == xH
-    @test HomogeneousPolynomial([2.1]) > 0.5 * xH > yH > xH^2
-    @test -1.0*xH < -yH^2 < 0 < HomogeneousPolynomial([1.0])
-    @test -3 < HomogeneousPolynomial([-2]) < 0.0
-    @test !(zero(yH^2) > 0)
     xT = TaylorN(xH, 17)
     yT = TaylorN(Int, 2, order=17)
     @test findfirst(xT) == 1
@@ -169,6 +165,16 @@ end
     @test TS.fixorder(xH,yH) == (xH,yH)
     @test_throws AssertionError TS.fixorder(zeros(xH,0)[1],yH)
 
+    @testset "Lexicographic order" begin
+        @test HomogeneousPolynomial([2.1]) > 0.5 * xH > yH > xH^2
+        @test -1.0*xH < -yH^2 < 0 < HomogeneousPolynomial([1.0])
+        @test -3 < HomogeneousPolynomial([-2]) < 0.0
+        @test !(zero(yH^2) > 0)
+        @test 1 > 0.5 * xT > yT > xT^2 > 0 > TaylorN(-1.0, 3)
+        @test -1 < -0.25 * yT < -xT^2 < 0.0 < TaylorN(1, 3)
+        @test !(zero(xT) > 0)
+        @test !(zero(yT^2) < 0)
+    end
 
     @test constant_term(xT) == 0
     @test constant_term(uT) == 1.0
@@ -231,10 +237,6 @@ end
     @test eltype(convert(TaylorN{Complex{Float64}},1)) == TaylorN{Complex{Float64}}
     @test TS.numtype(convert(TaylorN{Complex{Float64}},1)) == Complex{Float64}
     @test normalize_taylor(xT) == xT
-    @test 1 > 0.5 * xT > yT > xT^2 > 0 > TaylorN(-1.0, 3)
-    @test -1 < -0.25 * yT < -xT^2 < 0.0 < TaylorN(1, 3)
-    @test !(zero(xT) > 0)
-    @test !(zero(yT^2) < 0)
 
     @test 1+xT+yT == TaylorN(1,1) + TaylorN([xH,yH],1)
     @test xT-yT-1 == TaylorN([-1,xH-yH])
@@ -778,6 +780,7 @@ end
     @test yT[0] == xT[0]*(pi/180)
     TS.rad2deg!(yT, xT, 0)
     @test yT[0] == xT[0]*(180/pi)
+    # Lexicographic tests with 4 vars
     @test 1 > dx[1] > dx[2] > dx[3] > dx[4]
     @test dx[4]^2 < dx[3]*dx[4] < dx[3]^2 < dx[2]*dx[4] < dx[2]*dx[3] < dx[2]^2 < dx[1]*dx[4] < dx[1]*dx[3] < dx[1]*dx[2] < dx[1]^2
 end

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -23,10 +23,13 @@ using LinearAlgebra
     @test TS.numtype(tN) == TaylorN{Float64}
     @test normalize_taylor(tN) == tN
     @test tN.order == 3
-    @test HomogeneousPolynomial([1]) > xH > yH > 0.0
-    @test -xH^2 < -xH*yH < -yH^2 < -xH^3 < -yH^3 < HomogeneousPolynomial([0.0])
-    @test 1 ≥ tN > 2*tN^2 > 100*tN^3 > 0
-    @test -2*tN < -tN^2 ≤ 0
+
+    @testset "Lexicographic order: Taylor1{HomogeneousPolynomial{T}} and Taylor1{TaylorN{T}}" begin
+        @test HomogeneousPolynomial([1]) > xH > yH > 0.0
+        @test -xH^2 < -xH*yH < -yH^2 < -xH^3 < -yH^3 < HomogeneousPolynomial([0.0])
+        @test 1 ≥ tN > 2*tN^2 > 100*tN^3 > 0
+        @test -2*tN < -tN^2 ≤ 0
+    end
     @test string(zero(tN)) == "  0.0 + 𝒪(‖x‖¹) + 𝒪(t⁴)"
     @test string(tN) == " ( 1.0 + 𝒪(‖x‖¹)) t + 𝒪(t⁴)"
     @test string(tN + 3Taylor1(Int, 2)) == " ( 4.0 + 𝒪(‖x‖¹)) t + 𝒪(t³)"
@@ -113,10 +116,12 @@ using LinearAlgebra
     @test !(@inferred isnan(tN1))
     @test !(@inferred isinf(tN1))
 
-    @test 1 > xHt > yHt > xHt^2 > 0
-    @test -xHt^2 < -xHt*yHt < -yHt^2 < -xHt^3 < -yHt^3 < 0
-    @test 1 ≥ tN1 > 2*tN1^2 > 100*tN1^3 > 0
-    @test -2*tN1 < -tN1^2 ≤ 0
+    @testset "Lexicographic order: HomogeneousPolynomial{Taylor1{T}} and TaylorN{Taylor1{T}}" begin
+        @test 1 > xHt > yHt > xHt^2 > 0
+        @test -xHt^2 < -xHt*yHt < -yHt^2 < -xHt^3 < -yHt^3 < 0
+        @test 1 ≥ tN1 > 2*tN1^2 > 100*tN1^3 > 0
+        @test -2*tN1 < -tN1^2 ≤ 0
+    end
 
     @test mod(tN1+1,1.0) == 0+tN1
     @test mod(tN1-1.125,2) == 0.875+tN1

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -23,8 +23,8 @@ using LinearAlgebra
     @test TS.numtype(tN) == TaylorN{Float64}
     @test normalize_taylor(tN) == tN
     @test tN.order == 3
-    @test 1 > xH > yH > 0
-    @test -xH^2 < -xH*yH < -yH^2 < -xH^3 < -yH^3 < 0
+    @test HomogeneousPolynomial([1]) > xH > yH > 0.0
+    @test -xH^2 < -xH*yH < -yH^2 < -xH^3 < -yH^3 < HomogeneousPolynomial([0.0])
     @test 1 ≥ tN > 2*tN^2 > 100*tN^3 > 0
     @test -2*tN < -tN^2 ≤ 0
     @test string(zero(tN)) == "  0.0 + 𝒪(‖x‖¹) + 𝒪(t⁴)"

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -14,6 +14,7 @@ using LinearAlgebra
     xH = HomogeneousPolynomial(Int, 1)
     yH = HomogeneousPolynomial(Int, 2)
     tN = Taylor1(TaylorN{Float64}, 3)
+    @test findfirst(tN) == 1
 
     @test convert(eltype(tN), tN) == tN
     @test eltype(xH) == HomogeneousPolynomial{Int}
@@ -43,6 +44,7 @@ using LinearAlgebra
 
     t = Taylor1(3)
     xHt = HomogeneousPolynomial(typeof(t), 1)
+    @test findfirst(xHt) == 1
     @test convert(eltype(xHt), xHt) === xHt
     @test eltype(xHt) == HomogeneousPolynomial{Taylor1{Float64}}
     @test TS.numtype(xHt) == Taylor1{Float64}
@@ -50,6 +52,7 @@ using LinearAlgebra
     @test string(xHt) == " ( 1.0 + 𝒪(t¹)) x₁"
     xHt = HomogeneousPolynomial([one(t), zero(t)])
     yHt = HomogeneousPolynomial([zero(t), t])
+    @test findfirst(yHt) == 2
     @test string(xHt) == " ( 1.0 + 𝒪(t⁴)) x₁"
     @test string(yHt) == " ( 1.0 t + 𝒪(t⁴)) x₂"
     @test string(HomogeneousPolynomial([t])) == " ( 1.0 t + 𝒪(t⁴))"
@@ -62,10 +65,13 @@ using LinearAlgebra
     @test (xHt+yHt)([1, 1]) == (xHt+yHt)((1, 1))
 
     tN1 = TaylorN([HomogeneousPolynomial([t]), xHt, yHt^2])
+    @test findfirst(tN1) == 0
     @test tN1[0] == HomogeneousPolynomial([t])
     @test tN1(t,one(t)) == 2t+t^2
+    @test findfirst(tN1(t,one(t))) == 1
     @test tN1([t,one(t)]) == tN1((t,one(t)))
     t1N = convert(Taylor1{TaylorN{Float64}}, tN1)
+    @test findfirst(zero(tN1)) == -1
     @test t1N[0] == HomogeneousPolynomial(1)
     ctN1 = convert(TaylorN{Taylor1{Float64}}, t1N)
     @test convert(eltype(tN1), tN1) === tN1
@@ -332,6 +338,7 @@ end
 @testset "Tests with nested Taylor1s" begin
     ti = Taylor1(3)
     to = Taylor1([zero(ti), one(ti)], 9)
+    @test findfirst(to) == 1
     @test TS.numtype(to) == Taylor1{Float64}
     @test normalize_taylor(to) == to
     @test normalize_taylor(Taylor1([zero(to), one(to)], 5)) == Taylor1([zero(to), one(to)], 5)
@@ -346,6 +353,7 @@ end
     @test tito / ti == to
     @test get_order(tito/ti) == get_order(to)
     @test ti^2-to^2 == (ti+to)*(ti-to)
+    @test findfirst(ti^2-to^2) == 0
     @test sin(to) ≈ Taylor1(one(ti) .* sin(Taylor1(10)).coeffs, 9)
     @test to(1 + ti) == 1 + ti
     @test to(1 + ti) isa Taylor1{Float64}

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -23,6 +23,10 @@ using LinearAlgebra
     @test TS.numtype(tN) == TaylorN{Float64}
     @test normalize_taylor(tN) == tN
     @test tN.order == 3
+    @test 1 > xH > yH > 0
+    @test -xH^2 < -xH*yH < -yH^2 < -xH^3 < -yH^3 < 0
+    @test 1 ≥ tN > 2*tN^2 > 100*tN^3 > 0
+    @test -2*tN < -tN^2 ≤ 0
     @test string(zero(tN)) == "  0.0 + 𝒪(‖x‖¹) + 𝒪(t⁴)"
     @test string(tN) == " ( 1.0 + 𝒪(‖x‖¹)) t + 𝒪(t⁴)"
     @test string(tN + 3Taylor1(Int, 2)) == " ( 4.0 + 𝒪(‖x‖¹)) t + 𝒪(t³)"
@@ -108,6 +112,11 @@ using LinearAlgebra
         "  1.0 x₁² + 𝒪(‖x‖³) + ( 2.0 x₁ + 𝒪(‖x‖³)) t + ( 1.0 + 𝒪(‖x‖³)) t² + ( 2.0 x₂² + 𝒪(‖x‖³)) t³ + 𝒪(t⁴)"
     @test !(@inferred isnan(tN1))
     @test !(@inferred isinf(tN1))
+
+    @test 1 > xHt > yHt > xHt^2 > 0
+    @test -xHt^2 < -xHt*yHt < -yHt^2 < -xHt^3 < -yHt^3 < 0
+    @test 1 ≥ tN1 > 2*tN1^2 > 100*tN1^3 > 0
+    @test -2*tN1 < -tN1^2 ≤ 0
 
     @test mod(tN1+1,1.0) == 0+tN1
     @test mod(tN1-1.125,2) == 0.875+tN1
@@ -347,6 +356,8 @@ end
     @test string(to^2) == " ( 1.0 + 𝒪(t⁴)) t² + 𝒪(t¹⁰)"
     @test ti + to == Taylor1([ti, one(ti)], 9)
     tito = ti * to
+    # @test ti > ti^2 > to > 0
+    # @test to^2 < toti < ti^2
     @test tito == Taylor1([zero(ti), ti], 9)
     @test tito / to == ti
     @test get_order(tito/to) == get_order(to)-1

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -356,6 +356,7 @@ end
     @test string(to^2) == " ( 1.0 + 𝒪(t⁴)) t² + 𝒪(t¹⁰)"
     @test ti + to == Taylor1([ti, one(ti)], 9)
     tito = ti * to
+    # The next tests are related to iss #326
     # @test ti > ti^2 > to > 0
     # @test to^2 < toti < ti^2
     @test tito == Taylor1([zero(ti), ti], 9)

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -45,8 +45,8 @@ Base.iszero(::SymbNumber) = false
     @test axes(t) == ()
     @test axes([t]) == (Base.OneTo(1),)
 
-    @test 1 + t ≥ 1 > t > t^2 ≥ zero(t)
-    @test -t < -t^2 ≤ 0
+    @test 1 + t ≥ 1.0 > t > t^2 ≥ zero(t)
+    @test -1/1000 < -t < -t^2 ≤ 0
 
     v = [1,2]
     @test typeof(TaylorSeries.resize_coeffs1!(v,3)) == Nothing

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -45,6 +45,9 @@ Base.iszero(::SymbNumber) = false
     @test axes(t) == ()
     @test axes([t]) == (Base.OneTo(1),)
 
+    @test 1 > t > t^2
+    @test 1 > -t^2 > -t
+
     v = [1,2]
     @test typeof(TaylorSeries.resize_coeffs1!(v,3)) == Nothing
     @test v == [1,2,0,0]

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -45,7 +45,7 @@ Base.iszero(::SymbNumber) = false
     @test axes(t) == ()
     @test axes([t]) == (Base.OneTo(1),)
 
-    @test 1 + t ≥ 1 > t > t^2
+    @test 1 + t ≥ 1 > t > t^2 ≥ zero(t)
     @test -t < -t^2 ≤ 0
 
     v = [1,2]
@@ -141,14 +141,14 @@ Base.iszero(::SymbNumber) = false
     @test length.( TaylorSeries.fixorder(zt, Taylor1([1], 1)) ) == (2, 2)
     @test eltype(TaylorSeries.fixorder(zt,Taylor1([1]))[1]) == Taylor1{Int}
     @test TS.numtype(TaylorSeries.fixorder(zt,Taylor1([1]))[1]) == Int
-    @test TaylorSeries.findfirst(t) == 1
-    @test TaylorSeries.findfirst(t^2) == 2
-    @test TaylorSeries.findfirst(ot) == 0
-    @test TaylorSeries.findfirst(zt) == -1
-    @test TaylorSeries.findlast(t) == 1
-    @test TaylorSeries.findlast(t^2) == 2
-    @test TaylorSeries.findlast(ot) == 0
-    @test TaylorSeries.findlast(zt) == -1
+    @test findfirst(t) == 1
+    @test findfirst(t^2) == 2
+    @test findfirst(ot) == 0
+    @test findfirst(zt) == -1
+    @test findlast(t) == 1
+    @test findlast(t^2) == 2
+    @test findlast(ot) == 0
+    @test findlast(zt) == -1
     @test iszero(zero(t))
     @test !iszero(one(t))
     @test @inferred isinf(Taylor1([typemax(1.0)]))

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -145,10 +145,6 @@ Base.iszero(::SymbNumber) = false
     @test findfirst(t^2) == 2
     @test findfirst(ot) == 0
     @test findfirst(zt) == -1
-    @test findlast(t) == 1
-    @test findlast(t^2) == 2
-    @test findlast(ot) == 0
-    @test findlast(zt) == -1
     @test iszero(zero(t))
     @test !iszero(one(t))
     @test @inferred isinf(Taylor1([typemax(1.0)]))

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -45,8 +45,8 @@ Base.iszero(::SymbNumber) = false
     @test axes(t) == ()
     @test axes([t]) == (Base.OneTo(1),)
 
-    @test 1 + t ≥ 1.0 > t > t^2 ≥ zero(t)
-    @test -1/1000 < -t < -t^2 ≤ 0
+    @test 1 + t ≥ 1.0 > 0.5 + t > t^2 ≥ zero(t)
+    @test -1.0 < -1/1000 - t  < -t < -t^2 ≤ 0
 
     v = [1,2]
     @test typeof(TaylorSeries.resize_coeffs1!(v,3)) == Nothing

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -45,8 +45,8 @@ Base.iszero(::SymbNumber) = false
     @test axes(t) == ()
     @test axes([t]) == (Base.OneTo(1),)
 
-    @test 1 > t > t^2
-    @test 1 > -t^2 > -t
+    @test 1 + t ≥ 1 > t > t^2
+    @test -t < -t^2 ≤ 0
 
     v = [1,2]
     @test typeof(TaylorSeries.resize_coeffs1!(v,3)) == Nothing

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -45,8 +45,10 @@ Base.iszero(::SymbNumber) = false
     @test axes(t) == ()
     @test axes([t]) == (Base.OneTo(1),)
 
-    @test 1 + t ≥ 1.0 > 0.5 + t > t^2 ≥ zero(t)
-    @test -1.0 < -1/1000 - t  < -t < -t^2 ≤ 0
+    @testset "Total order" begin
+        @test 1 + t ≥ 1.0 > 0.5 + t > t^2 ≥ zero(t)
+        @test -1.0 < -1/1000 - t  < -t < -t^2 ≤ 0
+    end
 
     v = [1,2]
     @test typeof(TaylorSeries.resize_coeffs1!(v,3)) == Nothing


### PR DESCRIPTION
Solves #209 

This PR implements the total order following [this paper](https://www.bmtdynamics.org/pub/papers/adtheory/adtheory.pdf) by M. Berz, "Automatic differentiation as nonarchimedean analysis", in Computer Arithmetic and Enclosure Methods, 439-450, Elsevier (1992).

cc @dlfivefifty, @KeithWM