### PR TITLE
Export norm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
-version = "0.15.1"
+version = "0.15.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -60,7 +60,7 @@ export getcoeff, derivative, integrate, differentiate,
     # jacobian, hessian, jacobian!, hessian!,
     ∇, taylor_expand, update!,
     constant_term, linear_polynomial, nonlinear_polynomial,
-    normalize_taylor
+    normalize_taylor, norm
 
 const TS = TaylorSeries
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,36 @@
+# This file is part of the TaylorSeries.jl Julia package, MIT license
+#
+# Luis Benet & David P. Sanders
+# UNAM
+#
+# MIT Expat license
+#
+
+using PrecompileTools
+
+@setup_workload begin
+    # Putting some things in `@setup_workload` instead of `@compile_workload` can reduce the size of the
+    # precompile file and potentially make loading faster.
+    t = Taylor1(20)
+    δ = set_variables("δ", order=6, numvars=2)
+    tN = one(δ[1]) + Taylor1(typeof(δ[1]), 20)
+    # tb = Taylor1(Float128, 20)
+    # δb = zero(Float128) .+ δ
+    # tbN = one(δb[1]) + Taylor1(typeof(δb[1]), 20)
+    #
+    @compile_workload begin
+        # all calls in this block will be precompiled, regardless of whether
+        # they belong to your package or not (on Julia 1.8 and higher)
+        for x in (:t, :tN)
+            @eval begin
+                T = numtype($x)
+                zero($x)
+                sin($x)
+                cos($x)
+                $x/sqrt($x^2+(2*$x)^2)
+                evaluate(($x)^3, 0.125)
+                ($x)[2]
+            end
+        end
+    end
+end

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -3,7 +3,7 @@
 using TaylorSeries
 
 using Test
-using LinearAlgebra
+# using LinearAlgebra
 
 @testset "Test hash tables" begin
     # Issue #85 is solved!

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -4,7 +4,7 @@
 using TaylorSeries
 
 using Test
-using LinearAlgebra
+# using LinearAlgebra
 
 @testset "Tests with mixtures of Taylor1 and TaylorN" begin
     @test TaylorSeries.NumberNotSeries == Union{Real,Complex}
@@ -231,7 +231,7 @@ using LinearAlgebra
     F(x) = [sin(sin(x[4]+x[3])), sin(cos(x[3]-x[2])), cos(sin(x[1]^2+x[2]^2)), cos(cos(x[2]*x[3]))]
     Q = F(v+dx)
     diff_evals = cos(sin(dx[1]))-p(P[1])
-    @test norm( norm.(map(x->x.coeffs, diff_evals.coeffs),Inf) , Inf) < 1e-15
+    @test norm(diff_evals, Inf) < 1e-15
     #evaluate a Taylor1 at a TaylorN
     @test p(P) == evaluate(p, P)
     @test q(Q) == evaluate(q, Q)
@@ -279,7 +279,7 @@ using LinearAlgebra
     a11 = Taylor1([t,t^2,exp(-t),sin(t),cos(t)])
     b11 = t+t*(t^2)+(t^2)*(exp(-t))+(t^3)*sin(t)+(t^4)*cos(t)
     diff_a11b11 = a11(t)-b11
-    @test norm(diff_a11b11.coeffs,Inf) < 1E-19
+    @test norm(diff_a11b11.coeffs, Inf) < 1E-19
 
     X, Y = set_variables(Taylor1{Float64}, "x y")
     @test typeof( norm(X) ) == Float64

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -558,8 +558,8 @@ Base.iszero(::SymbNumber) = false
     @test typeof( norm(Taylor1(rnd)) ) == Float64
     @test norm(Taylor1(rnd)) > 0
     @test norm(t_a) == norm(a)
-    @test norm(Taylor1(a,15),3) == sum((a.^3))^(1/3)
-    @test norm(t_a,Inf) == 12
+    @test norm(Taylor1(a,15), 3) == sum((a.^3))^(1/3)
+    @test norm(t_a, Inf) == 12
     @test norm(t_C) == norm(complex(3.0,4.0)*a)
 
     @test TaylorSeries.rtoldefault(Taylor1{Int}) == 0


### PR DESCRIPTION
This PR exports `norm`; currently, it is needed to load first LinearAlgebra to use it.