### PR TITLE
Add compat for Aqua and stdlibs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,13 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+Aqua = "0.8"
 IntervalArithmetic = "0.15, 0.16, 0.17, 0.18, 0.19, 0.20"
+LinearAlgebra = "<0.0.1, 1"
+Markdown = "<0.0.1, 1"
 Requires = "0.5.2, 1"
+SparseArrays = "<0.0.1, 1"
+Test = "<0.0.1, 1"
 julia = "1"
 
 [extensions]

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -24,7 +24,9 @@ end
     Aqua.test_undefined_exports(TaylorSeries)
     Aqua.test_deps_compat(TaylorSeries)
     Aqua.test_stale_deps(TaylorSeries; ignore=[:Requires])
-    Aqua.test_piracy(TaylorSeries)
+    Aqua.test_piracies(TaylorSeries)
+    Aqua.test_unbound_args(TaylorSeries)
+    Aqua.test_project_extras(TaylorSeries)
 end
 
 nothing


### PR DESCRIPTION
TaylorSeries.jl did not specify a compat for Aqua. Aqua 0.8 introduces some breaking changes, such as renaming `test_piracy` to `test_piracies`, leading to broken test if one has a recent version of Aqua in their environment.

I added a compat for Aqua. New versions of Aqua also check for compats for standard libraries (which will be a requirement to publish the package), so I added those as well.