### PR TITLE
Fix bug in Taylor1 constructor for mixtures and add tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
-version = "0.15.2"
+version = "0.15.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -48,7 +48,7 @@ Taylor1(x::Taylor1{T}) where {T<:Number} = x
 Taylor1(coeffs::Array{T,1}, order::Int) where {T<:Number} = Taylor1{T}(coeffs, order)
 Taylor1(coeffs::Array{T,1}) where {T<:Number} = Taylor1(coeffs, length(coeffs)-1)
 function Taylor1(x::T, order::Int) where {T<:Number}
-    v = fill(zero(x), order+1)
+    v = [zero(x) for _ in 1:order+1]
     v[1] = x
     return Taylor1(v, order)
 end

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -351,7 +351,6 @@ using Test
     z0N = -1.333+get_variables()[1]
     z = Taylor1(z0N,20)
     z[20][1][1] = 5.0
-    @show z z[20][1].coeffs
     @test z[0][0][1] == -1.333
     @test z[20][1][1] == 5.0
     for i in 1:19

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -347,6 +347,19 @@ using Test
     @test_throws ArgumentError Taylor1(2) - TaylorN(1)
     @test_throws ArgumentError Taylor1(2) * TaylorN(1)
     @test_throws ArgumentError TaylorN(2) / Taylor1(1)
+
+    z0N = -1.333+get_variables()[1]
+    z = Taylor1(z0N,20)
+    z[20][1][1] = 5.0
+    @show z z[20][1].coeffs
+    @test z[0][0][1] == -1.333
+    @test z[20][1][1] == 5.0
+    for i in 1:19
+        for j in eachindex(z[i].coeffs)
+            @test all(z[i].coeffs[j][:] .== 0.0)
+        end
+    end
+    @test all(z[20][1][2:end] .== 0.0)
 end
 
 @testset "Tests with nested Taylor1s" begin

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -348,6 +348,7 @@ using Test
     @test_throws ArgumentError Taylor1(2) * TaylorN(1)
     @test_throws ArgumentError TaylorN(2) / Taylor1(1)
 
+    # Issue #342 and PR #343
     z0N = -1.333+get_variables()[1]
     z = Taylor1(z0N,20)
     z[20][1][1] = 5.0
@@ -359,7 +360,13 @@ using Test
         end
     end
     @test all(z[20][1][2:end] .== 0.0)
-    @test differentiate(integrate(z)) ≈ z
+    intz = integrate(z)
+    intz[20] = z[0]
+    @test intz[1] == z[0]
+    @test intz[20] == z[0]
+    for i in 2:19
+        @test iszero(intz[i])
+    end
 end
 
 @testset "Tests with nested Taylor1s" begin

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -359,6 +359,7 @@ using Test
         end
     end
     @test all(z[20][1][2:end] .== 0.0)
+    @test differentiate(integrate(z)) ≈ z
 end
 
 @testset "Tests with nested Taylor1s" begin


### PR DESCRIPTION
Fixes #342. Essentially, `fill` was used in a `Taylor1` constructor around here
https://github.com/JuliaDiff/TaylorSeries.jl/blob/5895948554c7161bf93aaa9f59543d8bbbbae236/src/constructors.jl#L51
which [according to the docs](https://docs.julialang.org/en/v1/base/arrays/#Base.fill) works fine when the underlying type is immutable, but causes issues for mutable types, such as `Array`.