### PR TITLE
Small fix in Taylor1 constructor?

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -49,7 +49,7 @@ Taylor1(coeffs::Array{T,1}, order::Int) where {T<:Number} = Taylor1{T}(coeffs, o
 Taylor1(coeffs::Array{T,1}) where {T<:Number} = Taylor1(coeffs, length(coeffs)-1)
 function Taylor1(x::T, order::Int) where {T<:Number}
     v = [zero(x) for _ in 1:order+1]
-    v[1] = x
+    v[1] = deepcopy(x)
     return Taylor1(v, order)
 end
 

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -367,6 +367,13 @@ using Test
     for i in 2:19
         @test iszero(intz[i])
     end
+
+    a = sum(exp.(get_variables()).^2)
+    b = Taylor1([a])
+    bcopy = deepcopy(b)
+    c = Taylor1(constant_term(b),1)
+    c[0][0][1] = 0.0
+    b == bcopy
 end
 
 @testset "Tests with nested Taylor1s" begin

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -371,7 +371,7 @@ using Test
     a = sum(exp.(get_variables()).^2)
     b = Taylor1([a])
     bcopy = deepcopy(b)
-    c = Taylor1(constant_term(b),1)
+    c = Taylor1(constant_term(b),0)
     c[0][0][1] = 0.0
     b == bcopy
 end


### PR DESCRIPTION
This PR is a bit related to #342 and #343 and represents a solution to the following (unexpected?) behavior: if we have a `Taylor1{TaylorN{Float64}}` constructed from another variable of the same type, modifying in-place the former modifies also the latter:

```julia
julia> using TaylorSeries

julia> set_variables("x", numvars=2, order=2)
2-element Vector{TaylorN{Float64}}:
  1.0 x₁ + 𝒪(‖x‖³)
  1.0 x₂ + 𝒪(‖x‖³)

julia> a = sum(exp.(get_variables()).^2)
 2.0 + 2.0 x₁ + 2.0 x₂ + 2.0 x₁² + 2.0 x₂² + 𝒪(‖x‖³)

julia> b = Taylor1([a])
  2.0 + 2.0 x₁ + 2.0 x₂ + 2.0 x₁² + 2.0 x₂² + 𝒪(‖x‖³) + 𝒪(t¹)

julia> bcopy = deepcopy(b)
  2.0 + 2.0 x₁ + 2.0 x₂ + 2.0 x₁² + 2.0 x₂² + 𝒪(‖x‖³) + 𝒪(t¹)

julia> c = Taylor1(constant_term(b),0)
  2.0 + 2.0 x₁ + 2.0 x₂ + 2.0 x₁² + 2.0 x₂² + 𝒪(‖x‖³) + 𝒪(t¹)

julia> c[0][0][1] = 0.0
0.0

julia> b == bcopy # I would expect this to be true, since only c was modified
false
```

What are your thoughts over this @lbenet?
