### PR TITLE
Further reduction of allocs in mutating methods for mixtures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
-version = "0.17.0"
+version = "0.17.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -72,6 +72,7 @@ resize_coeffsHP!
 numtype
 mul!
 mul!(::HomogeneousPolynomial, ::HomogeneousPolynomial, ::HomogeneousPolynomial)
+mul_scalar!(::HomogeneousPolynomial, ::NumberNotSeries, ::HomogeneousPolynomial, ::HomogeneousPolynomial)
 mul!(::Vector{Taylor1{T}}, ::Union{Matrix{T},SparseMatrixCSC{T}},::Vector{Taylor1{T}}) where {T<:Number}
 div!
 pow!

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -810,7 +810,10 @@ end
 
     @inbounds mul!(c[k], c[0], b[k])
     @inbounds for i = 1:k-1
-        c[k] += c[i] * b[k-i]
+        # c[k] += c[i] * b[k-i]
+        for ord in eachindex(c[k])
+            mul!(c[k], c[i], b[k-i], ord)
+        end
     end
     @inbounds c[k] = -c[k]/b[0]
     return nothing

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -979,8 +979,8 @@ end
     return nothing
 end
 
-# In-place division and assignment: c[k] = c[k] / a[k]
-# NOTE: Here `div!` *accumulates* the result of c[k] / a[k] in c[k] (k > 0)
+# In-place division and assignment: c[k] = (c/a)[k]
+# NOTE: Here `div!` *accumulates* the result of (c/a)[k] in c[k] (k > 0)
 #
 # Recursion algorithm:
 #
@@ -1005,8 +1005,8 @@ end
     return nothing
 end
 
-# In-place division and assignment: c[k] <- scalar * c[k] / a[k]
-# NOTE: Here `div!` *accumulates* the result of scalar * c[k] / a[k] in c[k] (k > 0)
+# In-place division and assignment: c[k] <- scalar * (c/a)[k]
+# NOTE: Here `div!` *accumulates* the result of scalar * (c/a)[k] in c[k] (k > 0)
 #
 # Recursion algorithm:
 #
@@ -1064,7 +1064,7 @@ function div_scalar!(c::TaylorN, scalar::NumberNotSeries, a::TaylorN)
     return nothing
 end
 
-# c[k] <- a[k]/b[k]
+# c[k] <- (a/b)[k]
 function div!(c::TaylorN, a::TaylorN, b::TaylorN)
     @inbounds for k in eachindex(c)
         div!(c, a, b, k)
@@ -1072,6 +1072,7 @@ function div!(c::TaylorN, a::TaylorN, b::TaylorN)
     return nothing
 end
 
+# c[k] <- (a/b)[k], where a is a scalar
 function div!(c::TaylorN, a::NumberNotSeries, b::TaylorN)
     @inbounds for k in eachindex(c)
         div!(c, a, b, k)
@@ -1079,6 +1080,7 @@ function div!(c::TaylorN, a::NumberNotSeries, b::TaylorN)
     return nothing
 end
 
+# c[k] <- a[k]/b, where b is a scalar
 function div!(c::TaylorN, a::TaylorN, b::NumberNotSeries)
     @inbounds for k in eachindex(c)
         div!(c[k], a[k], b)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -529,10 +529,12 @@ for T in (:Taylor1, :TaylorN)
         else
             @inbounds mul_scalar!(c[k], scalar, a[0], b[k])
         end
-        @inbounds for i = 1:k
-            if $T == Taylor1
+        if $T == Taylor1
+            @inbounds for i = 1:k
                 c[k] += a[i] * b[k-i]
-            else
+            end
+        else
+            @inbounds for i = 1:k
                 mul_scalar!(c[k], scalar, a[i], b[k-i])
             end
         end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -504,7 +504,7 @@ end
 mul!(res::Taylor1{TaylorN{T}}, a::Taylor1{TaylorN{T}},
 b::NumberNotSeries, k::Int) where {T<:NumberNotSeries} = mul!(res, b, a, k)
 
-# in-place division (assumes equal order among TaylorNs)
+# in-place product (assumes equal order among TaylorNs)
 function mul!(c::TaylorN, a::TaylorN, b::TaylorN)
     for k in eachindex(c)
         mul!(c, a, b, k)
@@ -811,9 +811,7 @@ end
     @inbounds mul!(c[k], c[0], b[k])
     @inbounds for i = 1:k-1
         # c[k] += c[i] * b[k-i]
-        for ord in eachindex(c[k])
-            mul!(c[k], c[i], b[k-i], ord)
-        end
+        mul!(c[k], c[i], b[k-i])
     end
     @inbounds c[k] = -c[k]/b[0]
     return nothing

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -510,13 +510,12 @@ for T in (:Taylor1, :TaylorN)
     @eval @inline function mul!(c::$T{T}, a::$T{T}, b::$T{T}, k::Int) where {T<:Number}
         if $T == Taylor1
             @inbounds c[k] = a[0] * b[k]
+            @inbounds for i = 1:k
+                c[k] += a[i] * b[k-i]
+            end
         else
             @inbounds mul!(c[k], a[0], b[k])
-        end
-        @inbounds for i = 1:k
-            if $T == Taylor1
-                c[k] += a[i] * b[k-i]
-            else
+            @inbounds for i = 1:k
                 mul!(c[k], a[i], b[k-i])
             end
         end
@@ -525,15 +524,12 @@ for T in (:Taylor1, :TaylorN)
 
     @eval @inline function mul_scalar!(c::$T{T}, scalar::NumberNotSeries, a::$T{T}, b::$T{T}, k::Int) where {T<:Number}
         if $T == Taylor1
-            @inbounds c[k] = a[0] * b[k]
-        else
-            @inbounds mul_scalar!(c[k], scalar, a[0], b[k])
-        end
-        if $T == Taylor1
+            @inbounds c[k] = scalar * a[0] * b[k]
             @inbounds for i = 1:k
-                c[k] += a[i] * b[k-i]
+                c[k] += scalar * a[i] * b[k-i]
             end
         else
+            @inbounds mul_scalar!(c[k], scalar, a[0], b[k])
             @inbounds for i = 1:k
                 mul_scalar!(c[k], scalar, a[i], b[k-i])
             end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -566,6 +566,7 @@ mul!(res::Taylor1{TaylorN{T}}, a::Taylor1{TaylorN{T}},
 b::NumberNotSeries, k::Int) where {T<:NumberNotSeries} = mul!(res, b, a, k)
 
 # in-place product (assumes equal order among TaylorNs)
+# NOTE: the result of the product is *accumulated* in c[k]
 function mul!(c::TaylorN, a::TaylorN, b::TaylorN)
     for k in eachindex(c)
         mul!(c, a, b, k)
@@ -871,6 +872,14 @@ end
     end
     # @inbounds c[k] = -c[k]/b[0]
     @inbounds divsubst!(c[k], b[0])
+    return nothing
+end
+
+# TODO: avoid allocations when T isa Taylor1
+@inline function div!(v::HomogeneousPolynomial{T}, a::HomogeneousPolynomial{T}, b::T) where {T <: Number}
+    @inbounds for k in eachindex(v)
+        v[k] = a[k] / b
+    end
     return nothing
 end
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -386,6 +386,14 @@ for (f, fc) in ((:+, :(add!)), (:-, :(subst!)))
             end
             return nothing
         end
+        function ($fc)(v::Taylor1{TaylorN{T}}, a::NumberNotSeries, b::Taylor1{TaylorN{T}}, k::Int) where {T<:NumberNotSeries}
+            @inbounds for i in eachindex(v[k])
+                for j in eachindex(v[k][i])
+                    v[k][i][j] = ($f)(k==0 && i==0 && j==1 ? a : zero(a), b[k][i][j])
+                end
+            end
+            return nothing
+        end
         function ($fc)(v::Taylor1{TaylorN{T}}, a::Taylor1{TaylorN{T}}, k::Int) where {T<:NumberNotSeries}
             @inbounds for l in eachindex(v[k])
                 for m in eachindex(v[k][l])

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -311,10 +311,27 @@ end
     return nothing
 end
 
+@inline function identity!(c::HomogeneousPolynomial{T}, a::HomogeneousPolynomial{T}, k::Int) where {T<:NumberNotSeries}
+    @inbounds c[k] = identity(a[k])
+    return nothing
+end
+
 for T in (:Taylor1, :TaylorN)
     @eval begin
-        @inline function identity!(c::$T{T}, a::$T{T}, k::Int) where {T<:Number}
-            @inbounds c[k] = identity(a[k])
+        @inline function identity!(c::$T{T}, a::$T{T}, k::Int) where {T<:NumberNotSeries}
+            if $T == Taylor1
+                @inbounds c[k] = identity(a[k])
+            else
+                @inbounds for l in eachindex(c[k])
+                    identity!(c[k], a[k], l)
+                end
+            end
+            return nothing
+        end
+        @inline function identity!(c::$T{T}, a::$T{T}, k::Int) where {T<:AbstractSeries}
+            @inbounds for l in eachindex(c[k])
+                identity!(c[k], a[k], l)
+            end
             return nothing
         end
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -370,16 +370,15 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
             zero!(c, k)
-            @inbounds for i = 0:k-1
-                if $T == Taylor1
-                    c[k] += (k-i) * a[k-i] * c[i]
-                else
-                    mul_scalar!(c[k], k-i, a[k-i], c[i])
-                end
-            end
             if $T == Taylor1
+                @inbounds for i = 0:k-1
+                    c[k] += (k-i) * a[k-i] * c[i]
+                end
                 @inbounds div!(c, c, k, k)
             else
+                @inbounds for i = 0:k-1
+                    mul_scalar!(c[k], k-i, a[k-i], c[i])
+                end
                 @inbounds div!(c[k], c[k], k)
             end
             return nothing
@@ -394,19 +393,15 @@ for T in (:Taylor1, :TaylorN)
             c0 = c[0]+one(c[0])
             if $T == Taylor1
                 @inbounds c[k] = k * a[k] * c0
-            else
-                @inbounds mul_scalar!(c[k], k, a[k], c0)
-            end
-            @inbounds for i = 1:k-1
-                if $T == Taylor1
+                @inbounds for i = 1:k-1
                     c[k] += (k-i) * a[k-i] * c[i]
-                else
-                    mul_scalar!(c[k], k-i, a[k-i], c[i])
                 end
-            end
-            if $T == Taylor1
                 @inbounds div!(c, c, k, k)
             else
+                @inbounds mul_scalar!(c[k], k, a[k], c0)
+                @inbounds for i = 1:k-1
+                    mul_scalar!(c[k], k-i, a[k-i], c[i])
+                end
                 @inbounds div!(c[k], c[k], k)
             end
             return nothing
@@ -421,10 +416,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
             zero!(c, k)
-            @inbounds for i = 1:k-1
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i = 1:k-1
                     c[k] += (k-i) * a[i] * c[k-i]
-                else
+                end
+            else
+                @inbounds for i = 1:k-1
                     mul_scalar!(c[k], k-i, a[i], c[k-i])
                 end
             end
@@ -446,10 +443,12 @@ for T in (:Taylor1, :TaylorN)
             a0 = constant_term(a)
             a0p1 = a0+one(a0)
             zero!(c, k)
-            @inbounds for i = 1:k-1
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i = 1:k-1
                     c[k] += (k-i) * a[i] * c[k-i]
-                else
+                end
+            else
+                @inbounds for i = 1:k-1
                     mul_scalar!(c[k], k-i, a[i], c[k-i])
                 end
             end
@@ -469,12 +468,14 @@ for T in (:Taylor1, :TaylorN)
             end
             zero!(s, k)
             zero!(c, k)
-            @inbounds for i = 1:k
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i = 1:k
                     x = i * a[i]
                     s[k] += x * c[k-i]
                     c[k] -= x * s[k-i]
-                else
+                end
+            else
+                @inbounds for i = 1:k
                     mul_scalar!(s[k],  i, a[i], c[k-i])
                     mul_scalar!(c[k], -i, a[i], s[k-i])
                 end
@@ -518,10 +519,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
             zero!(c, k)
-            @inbounds for i = 0:k-1
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i = 0:k-1
                     c[k] += (k-i) * a[k-i] * c2[i]
-                else
+                end
+            else
+                @inbounds for i = 0:k-1
                     mul_scalar!(c[k], k-i, a[k-i], c2[i])
                 end
             end
@@ -551,10 +554,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
             zero!(c, k)
-            @inbounds for i in 1:k-1
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i in 1:k-1
                     c[k] += (k-i) * r[i] * c[k-i]
-                else
+                end
+            else
+                @inbounds for i in 1:k-1
                     mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
@@ -586,10 +591,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
             zero!(c, k)
-            @inbounds for i in 1:k-1
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i in 1:k-1
                     c[k] += (k-i) * r[i] * c[k-i]
-                else
+                end
+            else
+                @inbounds for i in 1:k-1
                     mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
@@ -616,10 +623,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
             zero!(c, k)
-            @inbounds for i in 1:k-1
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i in 1:k-1
                     c[k] += (k-i) * r[i] * c[k-i]
-                else
+                end
+            else
+                @inbounds for i in 1:k-1
                     mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
@@ -643,12 +652,14 @@ for T in (:Taylor1, :TaylorN)
             x = a[1]
             zero!(s, k)
             zero!(c, k)
-            @inbounds for i = 1:k
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i = 1:k
                     x = i * a[i]
                     s[k] += x * c[k-i]
                     c[k] += x * s[k-i]
-                else
+                end
+            else
+                @inbounds for i = 1:k
                     mul_scalar!(s[k], i, a[i], c[k-i])
                     mul_scalar!(c[k], i, a[i], s[k-i])
                 end
@@ -671,10 +682,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
             zero!(c, k)
-            @inbounds for i = 0:k-1
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i = 0:k-1
                     c[k] += (k-i) * a[k-i] * c2[i]
-                else
+                end
+            else
+                @inbounds for i = 0:k-1
                     mul_scalar!(c[k], k-i, a[k-i], c2[i])
                 end
             end
@@ -698,10 +711,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
             zero!(c, k)
-            @inbounds for i in 1:k-1
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i in 1:k-1
                     c[k] += (k-i) * r[i] * c[k-i]
-                else
+                end
+            else
+                @inbounds for i in 1:k-1
                     mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
@@ -718,10 +733,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
             zero!(c, k)
-            @inbounds for i in 1:k-1
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i in 1:k-1
                     c[k] += (k-i) * r[i] * c[k-i]
-                else
+                end
+            else
+                @inbounds for i in 1:k-1
                     mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
@@ -738,10 +755,12 @@ for T in (:Taylor1, :TaylorN)
                 return nothing
             end
             zero!(c, k)
-            @inbounds for i in 1:k-1
-                if $T == Taylor1
+            if $T == Taylor1
+                @inbounds for i in 1:k-1
                     c[k] += (k-i) * r[i] * c[k-i]
-                else
+                end
+            else
+                @inbounds for i in 1:k-1
                     mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -374,7 +374,7 @@ for T in (:Taylor1, :TaylorN)
                 if $T == Taylor1
                     c[k] += (k-i) * a[k-i] * c[i]
                 else
-                    mul!(c[k], a[k-i], c[i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, a[k-i], c[i])
                 end
             end
             if $T == Taylor1
@@ -395,13 +395,13 @@ for T in (:Taylor1, :TaylorN)
             if $T == Taylor1
                 @inbounds c[k] = k * a[k] * c0
             else
-                @inbounds mul!(c[k], a[k], c0, scalar=k)
+                @inbounds mul_scalar!(c[k], k, a[k], c0)
             end
             @inbounds for i = 1:k-1
                 if $T == Taylor1
                     c[k] += (k-i) * a[k-i] * c[i]
                 else
-                    mul!(c[k], a[k-i], c[i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, a[k-i], c[i])
                 end
             end
             if $T == Taylor1
@@ -425,7 +425,7 @@ for T in (:Taylor1, :TaylorN)
                 if $T == Taylor1
                     c[k] += (k-i) * a[i] * c[k-i]
                 else
-                    mul!(c[k], a[i], c[k-i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, a[i], c[k-i])
                 end
             end
             @inbounds c[k] = (a[k] - c[k]/k) / constant_term(a)
@@ -450,7 +450,7 @@ for T in (:Taylor1, :TaylorN)
                 if $T == Taylor1
                     c[k] += (k-i) * a[i] * c[k-i]
                 else
-                    mul!(c[k], a[i], c[k-i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, a[i], c[k-i])
                 end
             end
             @inbounds c[k] = (a[k] - c[k]/k) / a0p1
@@ -475,8 +475,8 @@ for T in (:Taylor1, :TaylorN)
                     s[k] += x * c[k-i]
                     c[k] -= x * s[k-i]
                 else
-                    mul!(s[k], a[i], c[k-i], scalar=i)
-                    mul!(c[k], a[i], s[k-i], scalar=-i)
+                    mul_scalar!(s[k],  i, a[i], c[k-i])
+                    mul_scalar!(c[k], -i, a[i], s[k-i])
                 end
             end
 
@@ -522,7 +522,7 @@ for T in (:Taylor1, :TaylorN)
                 if $T == Taylor1
                     c[k] += (k-i) * a[k-i] * c2[i]
                 else
-                    mul!(c[k], a[k-i], c2[i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, a[k-i], c2[i])
                 end
             end
             # c[k] <- c[k]/k
@@ -555,7 +555,7 @@ for T in (:Taylor1, :TaylorN)
                 if $T == Taylor1
                     c[k] += (k-i) * r[i] * c[k-i]
                 else
-                    mul!(c[k], r[i], c[k-i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
             # sqrt!(r, 1-a^2, k)
@@ -598,7 +598,7 @@ for T in (:Taylor1, :TaylorN)
                 if $T == Taylor1
                     c[k] += (k-i) * r[i] * c[k-i]
                 else
-                    mul!(c[k], r[i], c[k-i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
             sqrt!(r, 1-a^2, k)
@@ -618,7 +618,7 @@ for T in (:Taylor1, :TaylorN)
                 if $T == Taylor1
                     c[k] += (k-i) * r[i] * c[k-i]
                 else
-                    mul!(c[k], r[i], c[k-i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
             @inbounds sqr!(r, a, k)
@@ -662,7 +662,7 @@ for T in (:Taylor1, :TaylorN)
                 if $T == Taylor1
                     c[k] += (k-i) * a[k-i] * c2[i]
                 else
-                    mul!(c[k], a[k-i], c2[i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, a[k-i], c2[i])
                 end
             end
             @inbounds c[k] = a[k] - c[k]/k
@@ -683,7 +683,7 @@ for T in (:Taylor1, :TaylorN)
                 if $T == Taylor1
                     c[k] += (k-i) * r[i] * c[k-i]
                 else
-                    mul!(c[k], r[i], c[k-i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
             sqrt!(r, a^2+1, k)
@@ -703,7 +703,7 @@ for T in (:Taylor1, :TaylorN)
                 if $T == Taylor1
                     c[k] += (k-i) * r[i] * c[k-i]
                 else
-                    mul!(c[k], r[i], c[k-i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
             sqrt!(r, a^2-1, k)
@@ -723,7 +723,7 @@ for T in (:Taylor1, :TaylorN)
                 if $T == Taylor1
                     c[k] += (k-i) * r[i] * c[k-i]
                 else
-                    mul!(c[k], r[i], c[k-i], scalar=k-i)
+                    mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
             @inbounds sqr!(r, a, k)
@@ -750,7 +750,7 @@ end
     zero!(res[k])
     for i = 0:k-1
         @inbounds for ordQ in eachindex(a[0])
-            mul!(res[k], res[i], a[k-i], ordQ, scalar=k-i)
+            mul_scalar!(res[k], k-i, res[i], a[k-i], ordQ)
         end
     end
     div!(res, res, k, k)
@@ -874,8 +874,8 @@ end
     @inbounds for i = 1:k
         for ordQ in eachindex(a[0])
             # x[ordQ].coeffs .= i .* a[i][ordQ].coeffs
-            mul!(s[k], a[i], c[k-i], ordQ, scalar=i)
-            mul!(c[k], a[i], s[k-i], ordQ, scalar=i)
+            mul_scalar!(s[k], i, a[i], c[k-i], ordQ)
+            mul_scalar!(c[k], i, a[i], s[k-i], ordQ)
         end
     end
     div!(s, s, k, k)
@@ -913,7 +913,7 @@ end
     zero!(res[k])
     for i = 0:k-1
         @inbounds for ordQ in eachindex(a[0])
-            mul!(res[k], res2[i], a[k-i], ordQ, scalar=k-i)
+            mul_scalar!(res[k], k-i, res2[i], a[k-i], ordQ)
         end
     end
     @inbounds for ordQ in eachindex(a[0])
@@ -941,7 +941,7 @@ end
     zero!(res[k])
     for i in 1:k-1
         @inbounds for ordQ in eachindex(a[0])
-            mul!(res[k], res[k-i], r[i], ordQ, scalar=k-i)
+            mul_scalar!(res[k], k-i, res[k-i], r[i], ordQ)
         end
     end
     div!(res, res, k, k)
@@ -984,7 +984,7 @@ end
     zero!(res[k])
     for i in 1:k-1
         @inbounds for ordQ in eachindex(a[0])
-            mul!(res[k], res[k-i], r[i], ordQ, scalar=k-i)
+            mul_scalar!(res[k], k-i, res[k-i], r[i], ordQ)
         end
     end
     div!(res, res, k, k)
@@ -1022,7 +1022,7 @@ end
     zero!(res[k])
     for i in 1:k-1
         @inbounds for ordQ in eachindex(a[0])
-            mul!(res[k], res[k-i], r[i], ordQ, scalar=k-i)
+            mul_scalar!(res[k], k-i, res[k-i], r[i], ordQ)
         end
     end
     tmp = TaylorN( zero(a[0][0][1]), a[0].order )
@@ -1051,8 +1051,8 @@ end
     zero!(c[k])
     @inbounds for i = 1:k
         for ordQ in eachindex(a[0])
-            mul!(s[k], a[i], c[k-i], ordQ, scalar=i)
-            mul!(c[k], a[i], s[k-i], ordQ, scalar=i)
+            mul_scalar!(s[k], i, a[i], c[k-i], ordQ)
+            mul_scalar!(c[k], i, a[i], s[k-i], ordQ)
         end
     end
     div!(s, s, k, k)
@@ -1072,7 +1072,7 @@ end
     zero!(res[k])
     for i = 0:k-1
         @inbounds for ordQ in eachindex(a[0])
-            mul!(res[k], res2[i], a[k-i], ordQ, scalar=k-i)
+            mul_scalar!(res[k], k-i, res2[i], a[k-i], ordQ)
         end
     end
     tmp = TaylorN( zero(a[0][0][1]), a[0].order)
@@ -1105,7 +1105,7 @@ end
     zero!(res[k])
     for i in 1:k-1
         @inbounds for ordQ in eachindex(a[0])
-            mul!(res[k], res[k-i], r[i], ordQ, scalar=k-i)
+            mul_scalar!(res[k], k-i, res[k-i], r[i], ordQ)
         end
     end
     div!(res, res, k, k)
@@ -1148,7 +1148,7 @@ end
     zero!(res[k])
     for i in 1:k-1
         @inbounds for ordQ in eachindex(a[0])
-            mul!(res[k], res[k-i], r[i], ordQ, scalar=k-i)
+            mul_scalar!(res[k], k-i, res[k-i], r[i], ordQ)
         end
     end
     div!(res, res, k, k)
@@ -1186,7 +1186,7 @@ end
     zero!(res[k])
     for i in 1:k-1
         @inbounds for ordQ in eachindex(a[0])
-            mul!(res[k], res[k-i], r[i], ordQ, scalar=k-i)
+            mul_scalar!(res[k], k-i, res[k-i], r[i], ordQ)
         end
     end
     @inbounds for ordQ in eachindex(a[0])

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -625,15 +625,13 @@ for T in (:Taylor1, :TaylorN)
                 @inbounds for i in 1:k-1
                     c[k] += (k-i) * r[i] * c[k-i]
                 end
+                @inbounds sqr!(r, a, k)
+                @inbounds c[k] = (a[k] - c[k]/k) / constant_term(r)
             else
                 @inbounds for i in 1:k-1
                     mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
-            end
-            @inbounds sqr!(r, a, k)
-            if $T == Taylor1
-                @inbounds c[k] = (a[k] - c[k]/k) / constant_term(r)
-            else
+                @inbounds sqr!(r, a, k)
                 for l in eachindex(c[k])
                     @inbounds c[k][l] = (a[k][l] - c[k][l]/k) / constant_term(r)
                 end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -303,6 +303,14 @@ end
     return nothing
 end
 
+@inline function one!(c::Taylor1{TaylorN{T}}, k::Int) where {T<:NumberNotSeries}
+    zero!(c, k)
+    if k == 0
+        @inbounds c[0][0][1] = one(constant_term(c[0][0][1]))
+    end
+    return nothing
+end
+
 for T in (:Taylor1, :TaylorN)
     @eval begin
         @inline function identity!(c::$T{T}, a::$T{T}, k::Int) where {T<:Number}

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -601,7 +601,24 @@ for T in (:Taylor1, :TaylorN)
                     mul_scalar!(c[k], k-i, r[i], c[k-i])
                 end
             end
-            sqrt!(r, 1-a^2, k)
+            # sqrt!(r, 1-a^2, k)
+            # Compute auxiliary term s=1-a^2
+            s = ($T)(zero(a[0]), a.order)
+            one_s = one(s)
+            for i = 0:k
+                sqr!(s, a, i)
+                subst!(s, s, i)
+                if i == 0
+                    if $T == Taylor1
+                        s[0] = one(s[0]) - s[0]
+                    else
+                        s[0][1] = one(s[0][1]) - s[0][1]
+                    end
+                    add!(s, one_s, s, 0)
+                end
+            end
+            # Update aux term r = sqrt(s) = sqrt(1-a^2)
+            sqrt!(r, s, k)
             @inbounds c[k] = -(a[k] + c[k]/k) / constant_term(r)
             return nothing
         end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -523,16 +523,14 @@ for T in (:Taylor1, :TaylorN)
                 @inbounds for i = 0:k-1
                     c[k] += (k-i) * a[k-i] * c2[i]
                 end
+                # c[k] <- c[k]/k
+                div!(c, c, k, k)
             else
                 @inbounds for i = 0:k-1
                     mul_scalar!(c[k], k-i, a[k-i], c2[i])
                 end
-            end
-            # c[k] <- c[k]/k
-            if $T == Taylor1
-                div!(c, c, k, k) # Taylor1
-            else
-                div!(c[k], c[k], k) # TaylorN
+                # c[k] <- c[k]/k
+                div!(c[k], c[k], k)
             end
             # c[k] <- c[k] + a[k]
             add!(c, a, c, k)
@@ -658,16 +656,13 @@ for T in (:Taylor1, :TaylorN)
                     s[k] += x * c[k-i]
                     c[k] += x * s[k-i]
                 end
+                @inbounds div!(s, s, k, k)
+                @inbounds div!(c, c, k, k)
             else
                 @inbounds for i = 1:k
                     mul_scalar!(s[k], i, a[i], c[k-i])
                     mul_scalar!(c[k], i, a[i], s[k-i])
                 end
-            end
-            if $T == Taylor1
-                @inbounds div!(s, s, k, k)
-                @inbounds div!(c, c, k, k)
-            else
                 @inbounds div!(s[k], s[k], k)
                 @inbounds div!(c[k], c[k], k)
             end
@@ -686,14 +681,11 @@ for T in (:Taylor1, :TaylorN)
                 @inbounds for i = 0:k-1
                     c[k] += (k-i) * a[k-i] * c2[i]
                 end
+                @inbounds c[k] = a[k] - c[k]/k
             else
                 @inbounds for i = 0:k-1
                     mul_scalar!(c[k], k-i, a[k-i], c2[i])
                 end
-            end
-            if $T == Taylor1
-                @inbounds c[k] = a[k] - c[k]/k
-            else
                 @inbounds for l in eachindex(c[k])
                     c[k][l] = a[k][l] - c[k][l]/k
                 end

--- a/src/power.jl
+++ b/src/power.jl
@@ -257,7 +257,7 @@ end
     @inbounds for i = 0:k-1
         aux = r*(k-i) - i
         # c[k] += a[k-i]*c[i]*aux
-        mul!(c[k], a[k-i], c[i], scalar=aux)
+        mul_scalar!(c[k], aux, a[k-i], c[i])
     end
     # c[k] <- c[k]/(k * constant_term(a))
     @inbounds div!(c[k], c[k], k * constant_term(a))
@@ -307,7 +307,7 @@ end
         ((i+lnull) > a.order || (l0+kprime-i > a.order)) && continue
         aux = r*(kprime-i) - i
         @inbounds for ordQ in eachindex(res[ordT])
-            mul!(res[ordT], res[i+lnull], a[l0+kprime-i], ordQ, scalar=aux)
+            mul_scalar!(res[ordT], aux, res[i+lnull], a[l0+kprime-i], ordQ)
         end
     end
     @inbounds for ordQ in eachindex(res[ordT])
@@ -639,11 +639,11 @@ end
     end
     if kodd == 0
         # @inbounds c[k] <- c[k] - (c[kend+1])^2
-        @inbounds mul!(c[k], c[kend+1], c[kend+1], scalar=-1)
+        @inbounds mul_scalar!(c[k], -1, c[kend+1], c[kend+1])
     end
     @inbounds for i = 1:kend
         # c[k] <- c[k] - 2*c[i]*c[k-i]
-        mul!(c[k], c[i], c[k-i], scalar=-2)
+        mul_scalar!(c[k], -2, c[i], c[k-i])
     end
     # @inbounds c[k] <- c[k] / (2*c[0])
     div!(c[k], c[k], 2*constant_term(c))
@@ -687,11 +687,11 @@ end
     if kodd == 0
         # c[k] <- c[k] - c[kend+1]^2
         # TODO: use accsqr! here?
-        @inbounds mul!(c[k], c[kend+k0+1], c[kend+k0+1], scalar=-1)
+        @inbounds mul_scalar!(c[k], -1, c[kend+k0+1], c[kend+k0+1])
     end
     @inbounds for i = imin:imax
         # c[k] <- c[k] - 2 * c[i] * c[k+k0-i]
-        mul!(c[k], c[i], c[k+k0-i], scalar=-2)
+        mul_scalar!(c[k], -2, c[i], c[k+k0-i])
     end
     # @inbounds c[k] <- c[k] / (2*c[k0])
     @inbounds div!(c[k], c[k0], scalar=0.5)

--- a/src/power.jl
+++ b/src/power.jl
@@ -255,7 +255,8 @@ end
     # The recursion formula
     for i = 0:k-1
         aux = r*(k-i) - i
-        mul!(c[k], aux*a[k-i], c[i])
+        # c[k] += a[k-i]*c[i]*aux
+        mul!(c[k], a[k-i], c[i], aux)
     end
     @inbounds for i in eachindex(c[k])
         c[k][i] = c[k][i] / (k * constant_term(a))

--- a/src/power.jl
+++ b/src/power.jl
@@ -415,16 +415,15 @@ for T = (:Taylor1, :TaylorN)
             # Recursion formula
             kodd = k%2
             kend = (k - 2 + kodd) >> 1
-            @inbounds for i = 0:kend
-                if $T == Taylor1
-                    c[k] += a[i] * a[k-i]
-                else
-                    mul!(c[k], a[i], a[k-i])
-                end
-            end
             if $T == Taylor1
+                @inbounds for i = 0:kend
+                    c[k] += a[i] * a[k-i]
+                end
                 @inbounds c[k] = 2 * c[k]
             else
+                @inbounds for i = 0:kend
+                    mul!(c[k], a[i], a[k-i])
+                end
                 @inbounds mul!(c, 2, c, k)
             end
             kodd == 1 && return nothing

--- a/src/power.jl
+++ b/src/power.jl
@@ -114,6 +114,7 @@ function ^(a::Taylor1{T}, r::S) where {T<:Number, S<:Real}
 end
 
 ## Real power ##
+# TODO: get rid of allocations
 function ^(a::TaylorN, r::S) where {S<:Real}
     a0 = constant_term(a)
     aux = one(a0^r)
@@ -296,6 +297,7 @@ end
     isinteger(r) && r > 0 && (ordT > r*findlast(a)) && return nothing
 
     if ordT == lnull
+        # TODO: get rid of allocations in ^(a::TaylorN, r::S) where {S<:Real}
         res[ordT] = a[l0]^r # if r is integer, uses power_by_squaring internally
         return nothing
     end

--- a/src/power.jl
+++ b/src/power.jl
@@ -683,11 +683,12 @@ end
         end
     end
     if kodd == 0
-        # @inbounds mul!(c[k], c[kend+1], c[kend+1], -1)
+        # c[k] <- c[k] - c[kend+1]^2
+        # TODO: use accsqr! here?
         @inbounds mul!(c[k], c[kend+k0+1], c[kend+k0+1], scalar=-1)
     end
     @inbounds for i = imin:imax
-        # c[k] += (-2) * c[i] * c[k+k0-i]
+        # c[k] <- c[k] - 2 * c[i] * c[k+k0-i]
         mul!(c[k], c[i], c[k+k0-i], scalar=-2)
     end
     # @inbounds c[k] <- c[k] / (2*c[k0])

--- a/src/power.jl
+++ b/src/power.jl
@@ -256,7 +256,7 @@ end
     for i = 0:k-1
         aux = r*(k-i) - i
         # c[k] += a[k-i]*c[i]*aux
-        mul!(c[k], a[k-i], c[i], aux)
+        mul!(c[k], a[k-i], c[i], scalar=aux)
     end
     @inbounds for i in eachindex(c[k])
         c[k][i] = c[k][i] / (k * constant_term(a))
@@ -642,11 +642,11 @@ end
     end
     if kodd == 0
         # @inbounds c[k] <- c[k] - (c[kend+1])^2
-        @inbounds mul!(c[k], c[kend+1], c[kend+1], -1)
+        @inbounds mul!(c[k], c[kend+1], c[kend+1], scalar=-1)
     end
     @inbounds for i = 1:kend
         # c[k] <- c[k] - 2*c[i]*c[k-i]
-        mul!(c[k], c[i], c[k-i], -2)
+        mul!(c[k], c[i], c[k-i], scalar=-2)
     end
     # @inbounds c[k] = c[k] / (2*c[0])
     div!(c[k], c[k], 2*constant_term(c))
@@ -708,12 +708,17 @@ end
         end
     end
     if kodd == 0
-        @inbounds c[k] += (-1)*c[kend+k0+1]*c[kend+k0+1]
+        # @inbounds mul!(c[k], c[kend+1], c[kend+1], -1)
+        @inbounds mul!(c[k], c[kend+k0+1], c[kend+k0+1], scalar=-1)
     end
     @inbounds for i = imin:imax
-        c[k] += (-2) * c[i] * c[k+k0-i]
+        # c[k] += (-2) * c[i] * c[k+k0-i]
+        mul!(c[k], c[i], c[k+k0-i], scalar=-2)
     end
-    @inbounds c[k] = c[k] / (2*c[k0])
+    # @inbounds c[k] <- c[k] / c[k0]
+    @inbounds div!(c[k], c[k0])
+    # @inbounds c[k] <- c[k] / 2
+    @inbounds mul!(c[k], 0.5, c[k])
 
     return nothing
 end

--- a/src/power.jl
+++ b/src/power.jl
@@ -366,7 +366,7 @@ end
     return nothing
 end
 @inline function sqr_orderzero!(c::TaylorN{Taylor1{T}}, a::TaylorN{Taylor1{T}}) where {T<:NumberNotSeries}
-    @inbounds c[0][1][0] = constant_term(a)^2
+    @inbounds c[0][1][0] = a[0][1][0]^2
     return nothing
 end
 

--- a/src/power.jl
+++ b/src/power.jl
@@ -297,8 +297,21 @@ end
     isinteger(r) && r > 0 && (ordT > r*findlast(a)) && return nothing
 
     if ordT == lnull
-        # TODO: get rid of allocations in ^(a::TaylorN, r::S) where {S<:Real}
-        res[ordT] = a[l0]^r # if r is integer, uses power_by_squaring internally
+        if isinteger(r)
+            # TODO: get rid of allocations here
+            res[ordT] = a[l0]^round(Int,r) # uses power_by_squaring
+            return nothing
+        end
+
+        a0 = constant_term(a[l0])
+        iszero(a0) && throw(DomainError(a[l0],
+            """The 0-th order TaylorN coefficient must be non-zero
+            in order to expand `^` around 0."""))
+
+        for ordQ in eachindex(a[l0])
+            pow!(res[ordT], a[l0], r, ordQ)
+        end
+
         return nothing
     end
 

--- a/src/power.jl
+++ b/src/power.jl
@@ -306,13 +306,11 @@ end
     for i = 0:ordT-lnull-1
         ((i+lnull) > a.order || (l0+kprime-i > a.order)) && continue
         aux = r*(kprime-i) - i
-        @inbounds for ordQ in eachindex(res[ordT])
-            mul_scalar!(res[ordT], aux, res[i+lnull], a[l0+kprime-i], ordQ)
-        end
+        # res[ordT] += aux*res[i+lnull]*a[l0+kprime-i]
+        @inbounds mul_scalar!(res[ordT], aux, res[i+lnull], a[l0+kprime-i])
     end
-    @inbounds for ordQ in eachindex(res[ordT])
-        div!(res[ordT], a[l0], ordQ, scalar=1/kprime)
-    end
+    # res[ordT] /= a[l0]*kprime
+    @inbounds div_scalar!(res[ordT], 1/kprime, a[l0])
 
     return nothing
 end
@@ -694,7 +692,7 @@ end
         mul_scalar!(c[k], -2, c[i], c[k+k0-i])
     end
     # @inbounds c[k] <- c[k] / (2*c[k0])
-    @inbounds div!(c[k], c[k0], scalar=0.5)
+    @inbounds div_scalar!(c[k], 0.5, c[k0])
 
     return nothing
 end


### PR DESCRIPTION
During the development of #347, @lbenet suggested a way to further reduce allocations in mutating division methods for mixtures (see [this comment](https://github.com/JuliaDiff/TaylorSeries.jl/pull/347#discussion_r1501682516)). After running some local tests, it indeed looks like an option worthwhile pursuing.

On current master:
```julia
julia> using BenchmarkTools

julia> using TaylorSeries
Precompiling TaylorSeries
  1 dependency successfully precompiled in 3 seconds. 3 already precompiled.

julia> dq = set_variables("δq", order=1, numvars=2)
2-element Vector{TaylorN{Float64}}:
  1.0 δq₁ + 𝒪(‖x‖²)
  1.0 δq₂ + 𝒪(‖x‖²)

julia> x = Taylor1([2+2dq[1],-1.1dq[1], 0.7dq[2], 0.5dq[1]-0.45dq[2],0.9dq[1]])
  2.0 + 2.0 δq₁ + 𝒪(‖x‖²) + ( - 1.1 δq₁ + 𝒪(‖x‖²)) t + ( 0.7 δq₂ + 𝒪(‖x‖²)) t² + ( 0.5 δq₁ - 0.45 δq₂ + 𝒪(‖x‖²)) t³ + ( 0.9 δq₁ + 𝒪(‖x‖²)) t⁴ + 𝒪(t⁵)

julia> z = deepcopy(x)
  2.0 + 2.0 δq₁ + 𝒪(‖x‖²) + ( - 1.1 δq₁ + 𝒪(‖x‖²)) t + ( 0.7 δq₂ + 𝒪(‖x‖²)) t² + ( 0.5 δq₁ - 0.45 δq₂ + 𝒪(‖x‖²)) t³ + ( 0.9 δq₁ + 𝒪(‖x‖²)) t⁴ + 𝒪(t⁵)

julia> TaylorSeries.zero!(z)

julia> iszero(z)
true

julia> z[0] = 1/x[0]
 0.5 - 0.5 δq₁ + 𝒪(‖x‖²)

julia> @btime TaylorSeries.div!($z, 1, $x, 1)
  735.992 ns (18 allocations: 1.27 KiB)

julia> @btime TaylorSeries.div!($z, 1, $x, 2)
  1.342 μs (36 allocations: 2.53 KiB)

julia> @btime TaylorSeries.div!($z, 1, $x, 3)
  2.000 μs (54 allocations: 3.80 KiB)

julia> @btime TaylorSeries.div!($z, 1, $x, 4)
  2.657 μs (72 allocations: 5.06 KiB)
```
This PR:
```julia
julia> @btime TaylorSeries.div!($z, 1, $x, 1)
  685.610 ns (18 allocations: 1.27 KiB)

julia> @btime TaylorSeries.div!($z, 1, $x, 2)
  708.029 ns (18 allocations: 1.27 KiB)

julia> @btime TaylorSeries.div!($z, 1, $x, 3)
  724.354 ns (18 allocations: 1.27 KiB)

julia> @btime TaylorSeries.div!($z, 1, $x, 4)
  740.625 ns (18 allocations: 1.27 KiB)
```
~~The remaining 18 allocations are coming from this line:
https://github.com/JuliaDiff/TaylorSeries.jl/blob/bc1735c32546415c1c254a342537c28c361f988b/src/arithmetic.jl#L815~~
EDIT: the afore-mentioned 18 allocations are not there anymore.

UPDATE: after successfully reducing allocation in mutating division and product methods for mixtures, these changes enabled further allocation reduction in sqrt, pow, and other functions. These improvements have also been added to this PR.