### PR TITLE
Add StaticArrays extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,9 +11,11 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [weakdeps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
 TaylorSeriesIAExt = "IntervalArithmetic"
+TaylorSeriesSAExt = "StaticArrays"
 
 [compat]
 Aqua = "0.8"
@@ -22,6 +24,7 @@ LinearAlgebra = "<0.0.1, 1"
 Markdown = "<0.0.1, 1"
 Requires = "0.5.2, 1"
 SparseArrays = "<0.0.1, 1"
+StaticArrays = "1"
 Test = "<0.0.1, 1"
 julia = "1"
 
@@ -30,7 +33,8 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["IntervalArithmetic", "LinearAlgebra", "SparseArrays", "Test", "Aqua"]
+test = ["IntervalArithmetic", "LinearAlgebra", "SparseArrays", "StaticArrays", "Test", "Aqua"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
-version = "0.17.2"
+version = "0.17.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/ext/TaylorSeriesSAExt.jl
+++ b/ext/TaylorSeriesSAExt.jl
@@ -9,5 +9,6 @@ isdefined(Base, :get_extension) ? (using StaticArrays) : (using ..StaticArrays)
 
 promote_op(::typeof(adjoint), ::Type{T}) where {T<:AbstractSeries} = T
 promote_op(::typeof(matprod), ::Type{T}, ::Type{U}) where {T <: AbstractSeries, U <: AbstractFloat} = T
+promote_op(::typeof(matprod), ::Type{T}, ::Type{T}) where {T <: AbstractSeries} = T
 
 end

--- a/ext/TaylorSeriesSAExt.jl
+++ b/ext/TaylorSeriesSAExt.jl
@@ -1,0 +1,13 @@
+module TaylorSeriesSAExt
+
+using TaylorSeries
+
+import Base.promote_op
+import LinearAlgebra: matprod
+
+isdefined(Base, :get_extension) ? (using StaticArrays) : (using ..StaticArrays)
+
+promote_op(::typeof(adjoint), ::Type{T}) where {T<:AbstractSeries} = T
+promote_op(::typeof(matprod), ::Type{T}, ::Type{U}) where {T <: AbstractSeries, U <: AbstractFloat} = T
+
+end

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -49,6 +49,8 @@ import Base: zero, one, zeros, ones, isinf, isnan, iszero, isless,
     power_by_squaring,
     rtoldefault, isfinite, isapprox, rad2deg, deg2rad
 
+import Base.float
+
 export Taylor1, TaylorN, HomogeneousPolynomial, AbstractSeries, TS
 
 export getcoeff, derivative, integrate, differentiate,

--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -84,6 +84,9 @@ function __init__()
         @require IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253" begin
             include("../ext/TaylorSeriesIAExt.jl")
         end
+        @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" begin
+            include("../ext/TaylorSeriesSAExt.jl")
+        end
     end
 end
 

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -201,3 +201,12 @@ function promote(a::Taylor1{Taylor1{T}}, b::Taylor1{T}) where {T<:NumberNotSerie
 end
 promote(b::Taylor1{T}, a::Taylor1{Taylor1{T}}) where {T<:NumberNotSeriesN} =
     reverse(promote(a, b))
+
+# float
+float(::Type{Taylor1{T}}) where T<:Number = Taylor1{float(T)}
+float(::Type{HomogeneousPolynomial{T}}) where T<:Number = HomogeneousPolynomial{float(T)}
+float(::Type{TaylorN{T}}) where T<:Number = TaylorN{float(T)}
+
+float(x::Taylor1{T}) where T<:Number = convert(Taylor1{float(T)}, x)
+float(x::HomogeneousPolynomial{T}) where T<:Number = convert(HomogeneousPolynomial{float(T)}, x)
+float(x::TaylorN{T}) where T<:Number = convert(TaylorN{float(T)}, x)

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -782,6 +782,15 @@ end
     # Lexicographic tests with 4 vars
     @test 1 > dx[1] > dx[2] > dx[3] > dx[4]
     @test dx[4]^2 < dx[3]*dx[4] < dx[3]^2 < dx[2]*dx[4] < dx[2]*dx[3] < dx[2]^2 < dx[1]*dx[4] < dx[1]*dx[3] < dx[1]*dx[2] < dx[1]^2
+
+    @testset "Test Base.float overloads for HomogeneousPolynomial and TaylorN" begin
+        @test float(HomogeneousPolynomial(-7, 2)) == HomogeneousPolynomial(-7.0, 2)
+        @test float(HomogeneousPolynomial(1+im, 2)) == HomogeneousPolynomial(float(1+im), 2)
+        @test float(TaylorN(Int, 2)) == TaylorN(2)
+        @test float(TaylorN(Complex{Rational}, 2)) == TaylorN(float(Complex{Rational}), 2)
+        @test float(HomogeneousPolynomial{Complex{Int}}) == float(HomogeneousPolynomial{Complex{Float64}})
+        @test float(TaylorN{Complex{Rational}}) == float(TaylorN{Complex{Float64}})
+    end
 end
 
 @testset "Integrate for several variables" begin

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -495,6 +495,17 @@ using Test
     two = 2one(x[0])
     @test two/x == 2/x == 2.0/x
     @test (2one(x))/x == 2/x
+
+    @testset "Test Base.float overloads for Taylor1 and TaylorN mixtures" begin
+        q = get_variables(Int)
+        x1N = Taylor1(q)
+        @test float(x1N) == Taylor1(float.(q))
+        xN1 = convert(TaylorN{Taylor1{Int}}, x1N)
+        @test float(xN1) == convert(TaylorN{Taylor1{Float64}}, Taylor1(float.(q)))
+        @test float(Taylor1{TaylorN{Int}}) == Taylor1{TaylorN{Float64}}
+        @test float(TaylorN{Taylor1{Int}}) == TaylorN{Taylor1{Float64}}
+        @test float(TaylorN{Taylor1{Complex{Int}}}) == TaylorN{Taylor1{Complex{Float64}}}
+    end
 end
 
 @testset "Tests with nested Taylor1s" begin

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -625,6 +625,17 @@ Base.iszero(::SymbNumber) = false
     # Test fallback pretty_print
     st = Taylor1([SymbNumber(:x₀), SymbNumber(:x₁)])
     @test string(st) == " SymbNumber(:x₀) + SymbNumber(:x₁) t + 𝒪(t²)"
+
+    @testset "Test Base.float overloads for Taylor1" begin
+        @test float(Taylor1(-3, 2)) == Taylor1(-3.0, 2)
+        @test float(Taylor1(-1//2, 2)) == Taylor1(-0.5, 2)
+        @test float(Taylor1(3 - 0im, 2)) == Taylor1(3.0 - 0.0im, 2)
+        x = Taylor1(rand(5))
+        @test float(x) == x
+        @test float(Taylor1{Int32}) == Taylor1{Float64}
+        @test float(Taylor1{Int}) == Taylor1{Float64}
+        @test float(Taylor1{Complex{Int}}) == Taylor1{ComplexF64}
+    end
 end
 
 @testset "Test inv for Matrix{Taylor1{Float64}}" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,8 @@ testfiles = (
     "intervals.jl",
     "broadcasting.jl",
     "identities_Euler.jl",
-    "fateman40.jl"
+    "fateman40.jl",
+    "staticarrays.jl"
     )
 
 for file in testfiles

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@
 # Tests for TaylorSeries
 
 testfiles = (
-    "aqua.jl",
     "onevariable.jl",
     "manyvariables.jl",
     "mixtures.jl",

--- a/test/staticarrays.jl
+++ b/test/staticarrays.jl
@@ -1,0 +1,18 @@
+# This file is part of TaylorSeries.jl, MIT licensed
+#
+
+using TaylorSeries, StaticArrays
+
+using Test
+# eeuler = Base.MathConstants.e
+
+@testset "Tests TaylorSeries operations over StaticArrays types" begin
+    q = set_variables("q", order=2, numvars=2)
+    m = @SMatrix fill(Taylor1(rand(2).*q), 3, 3)
+    mt = m'
+    @test m isa SMatrix{3, 3, Taylor1{TaylorN{Float64}}, 9}
+    @test mt isa SMatrix{3, 3, Taylor1{TaylorN{Float64}}, 9}
+    v = @SVector [-1.1, 3.4, 7.62345e-1]
+    mtv = mt * v
+    @test mtv isa SVector{3, Taylor1{TaylorN{Float64}}}
+end

--- a/test/staticarrays.jl
+++ b/test/staticarrays.jl
@@ -15,4 +15,6 @@ using Test
     v = @SVector [-1.1, 3.4, 7.62345e-1]
     mtv = mt * v
     @test mtv isa SVector{3, Taylor1{TaylorN{Float64}}}
+    mmt = m * mt
+    @test mmt isa SMatrix{3, 3, Taylor1{TaylorN{Float64}}, 9}
 end


### PR DESCRIPTION
Currently, when doing some operations with SMatrix and SVector, and TaylorSeries defined types are involved, the type of the returned value is not inferred correctly (especially for mixtures), which then have to be converted back to the desired types, but we can solve these issues by defining a couple of `Base.promote_op` dispatches for `Taylor1`, `TaylorN` and mixes thereof.

For example, in the following code
```julia
using TaylorSeries, StaticArrays
q = set_variables("q", order=2, numvars=2)
m = @SMatrix fill(Taylor1(rand(2).*q), 3, 3)
mt = m'
v = @SVector [-1.1, 3.4, 7.62345e-1]
mtv = mt * v
```
the matrix `m` is a `SMatrix{3, 3, Taylor1{TaylorN{Float64}}, 9}`, while `mt` is a `SMatrix{3, 3, Any, 9}` and `mtv` is a `SVector{3, Any}`. This PR solves these issues.