### PR TITLE
Add TaylorN constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
-version = "0.17.4"
+version = "0.17.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -211,5 +211,6 @@ const NumberNotSeries = Union{Real,Complex}
 # A `Number` which is not `TaylorN` nor a `HomogeneousPolynomial`
 const NumberNotSeriesN = Union{Real,Complex,Taylor1}
 
-## Additional Taylor1 outer constructor ##
+## Additional Taylor1 and TaylorN outer constructor ##
 Taylor1{T}(x::S) where {T<:Number,S<:NumberNotSeries} = Taylor1([convert(T,x)], 0)
+TaylorN{T}(x::S) where {T<:Number,S<:NumberNotSeries} = TaylorN(convert(T, x), TaylorSeries.get_order())

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -6,6 +6,9 @@ using Test
 # using LinearAlgebra
 
 @testset "Test hash tables" begin
+    a = TaylorN{Float64}(9//10)
+    a isa TaylorN{Float64}
+    @test constant_term(a) == Float64(9//10)
     # Issue #85 is solved!
     set_variables("x", numvars=66, order=1)
     @test TS._params_TaylorN_.order == get_order() == 1
@@ -791,6 +794,14 @@ end
         @test float(HomogeneousPolynomial{Complex{Int}}) == float(HomogeneousPolynomial{Complex{Float64}})
         @test float(TaylorN{Complex{Rational}}) == float(TaylorN{Complex{Float64}})
     end
+
+    a = TaylorN{Float64}(-1//3)
+    b = TaylorN{Float64}(1//7)
+    @test a !== b
+    @test a != b
+    b = identity(a) # identity is applied recursively on each coefficient
+    @test a !== b
+    @test a != b
 end
 
 @testset "Integrate for several variables" begin

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -795,13 +795,6 @@ end
         @test float(TaylorN{Complex{Rational}}) == float(TaylorN{Complex{Float64}})
     end
 
-    a = TaylorN{Float64}(-1//3)
-    b = TaylorN{Float64}(1//7)
-    @test a !== b
-    @test a != b
-    b = identity(a) # identity is applied recursively on each coefficient
-    @test a !== b
-    @test a != b
 end
 
 @testset "Integrate for several variables" begin

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -9,6 +9,9 @@ using Test
     a = TaylorN{Float64}(9//10)
     a isa TaylorN{Float64}
     @test constant_term(a) == Float64(9//10)
+    b = TaylorN{Complex{Float64}}(-4//7im)
+    @test b isa TaylorN{Complex{Float64}}
+    @test_throws MethodError TaylorN(-4//7im)
     # Issue #85 is solved!
     set_variables("x", numvars=66, order=1)
     @test TS._params_TaylorN_.order == get_order() == 1


### PR DESCRIPTION
This PR adds a `TaylorN` constructor which takes simply a `<:NumberNotSeries` variable and the current order from `get_order()`, which allows to do e.g.:
```julia
julia> a = TaylorN{Float64}(-1//3)
 -0.3333333333333333 + 𝒪(‖x‖⁷)

julia> typeof(a)
 TaylorN{Float64}
```