### PR TITLE
Avoid runtime-evaluated redundant `if`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
-version = "0.21.8"
+version = "0.21.9"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
 
 [deps]

--- a/ext/TaylorSeriesIAExt.jl
+++ b/ext/TaylorSeriesIAExt.jl
@@ -163,7 +163,7 @@ function TS.sqr!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}},
     TS.zero!(c, k)
     # Recursion formula
     kodd = k%2
-    kend = div(k - 2 + kodd, 2)
+    kend = (k - 2 + kodd) >> 1
     @inbounds for i = 0:kend
         c[k] += a[i] * a[k-i]
     end

--- a/ext/TaylorSeriesIAExt.jl
+++ b/ext/TaylorSeriesIAExt.jl
@@ -74,128 +74,161 @@ for T in (:Taylor1, :TaylorN)
 
         ^(a::$T{Interval{T}}, r::Rational) where {T<:NumTypes} = a^float(r)
 
-        function ^(a::$T{Interval{T}}, r::S) where {T<:NumTypes, S<:Real}
-            isinteger(r) && r ≥ 0 && return power_by_squaring(a, Integer(r))
-            a0 = _intersect_domain_nonstd(constant_term(a), interval(zero(T), T(Inf)))
-            @assert !isempty_interval(a0)
-            aux = one(a0^r)
-            aa = one(aux) * a
-            r == 0.5 && return sqrt(aa)
-            if $T == TaylorN
-                if TS._isthinzero(a0)
-                    throw(DomainError(aa,
-                    """The 0-th order TaylorN coefficient must be non-zero
-                    in order to expand `^` around 0."""))
-                end
-            end
-            return _pow(aa, r)
-        end
-
         # _pow
         function _pow(a::$T{Interval{S}}, n::Integer) where {S<:NumTypes}
             n < 0 && return _pow(a, float(n))
             return power_by_squaring(a, n)
         end
-
-        function _pow(a::$T{Interval{T}}, r::S) where {T<:NumTypes, S<:Real}
-            isinteger(r) && r ≥ 0 && return power_by_squaring(a, Integer(r))
-            a0 = _intersect_domain_nonstd(constant_term(a), interval(zero(T), T(Inf)))
-            @assert !isempty_interval(a0)
-            aux = one(a0^r)
-            a[0] = aux * a0
-            r == 0.5 && return sqrt(a)
-            a_order = get_order(a)
-            if $T == Taylor1
-                l0 = findfirst(a)
-                # Index of first non-zero coefficient of the result; must be integer
-                !isinteger(r*l0) && throw(DomainError(a,
-                    """The 0-th order Taylor1 coefficient must be non-zero
-                    to raise the Taylor1 polynomial to a non-integer exponent."""))
-                lnull = trunc(Int, r*l0 )
-                (lnull > a_order) && return $T( zero(aux), a_order)
-                c_order = l0 == 0 ? a_order : min(a_order, trunc(Int, r*a_order))
-            else
-                if TS._isthinzero(a0)
-                    throw(DomainError(a,
-                        """The 0-th order TaylorN coefficient must be non-zero
-                        in order to expand `^` around 0."""))
-                end
-                c_order = a_order
-            end
-            #
-            c = $T(zero(aux), c_order)
-            aux0 = zero(c)
-            for k in eachindex(c)
-                TS.pow!(c, a, aux0, r, k)
-            end
-            return c
-        end
     end
+end
+
+function ^(a::Taylor1{Interval{T}}, r::S) where {T<:NumTypes, S<:Real}
+    isinteger(r) && r >= 0 && return power_by_squaring(a, Integer(r))
+    a0 = _intersect_domain_nonstd(constant_term(a), interval(zero(T), T(Inf)))
+    @assert !isempty_interval(a0)
+    aux = one(a0^r)
+    aa = one(aux) * a
+    r == 0.5 && return sqrt(aa)
+    return _pow(aa, r)
+end
+
+function ^(a::TaylorN{Interval{T}}, r::S) where {T<:NumTypes, S<:Real}
+    isinteger(r) && r >= 0 && return power_by_squaring(a, Integer(r))
+    a0 = _intersect_domain_nonstd(constant_term(a), interval(zero(T), T(Inf)))
+    @assert !isempty_interval(a0)
+    aux = one(a0^r)
+    aa = one(aux) * a
+    r == 0.5 && return sqrt(aa)
+    if TS._isthinzero(a0)
+        throw(DomainError(aa,
+        """The 0-th order TaylorN coefficient must be non-zero
+        in order to expand `^` around 0."""))
+    end
+    return _pow(aa, r)
+end
+
+function _pow(a::Taylor1{Interval{T}}, r::S) where {T<:NumTypes, S<:Real}
+    isinteger(r) && r >= 0 && return power_by_squaring(a, Integer(r))
+    a0 = _intersect_domain_nonstd(constant_term(a), interval(zero(T), T(Inf)))
+    @assert !isempty_interval(a0)
+    aux = one(a0^r)
+    a[0] = aux * a0
+    r == 0.5 && return sqrt(a)
+    a_order = get_order(a)
+    l0 = findfirst(a)
+    # Index of first non-zero coefficient of the result; must be integer
+    !isinteger(r*l0) && throw(DomainError(a,
+        """The 0-th order Taylor1 coefficient must be non-zero
+        to raise the Taylor1 polynomial to a non-integer exponent."""))
+    lnull = trunc(Int, r*l0 )
+    (lnull > a_order) && return Taylor1( zero(aux), a_order)
+    c_order = l0 == 0 ? a_order : min(a_order, trunc(Int, r*a_order))
+    c = Taylor1(zero(aux), c_order)
+    aux0 = zero(c)
+    for k in eachindex(c)
+        TS.pow!(c, a, aux0, r, k)
+    end
+    return c
+end
+
+function _pow(a::TaylorN{Interval{T}}, r::S) where {T<:NumTypes, S<:Real}
+    isinteger(r) && r >= 0 && return power_by_squaring(a, Integer(r))
+    a0 = _intersect_domain_nonstd(constant_term(a), interval(zero(T), T(Inf)))
+    @assert !isempty_interval(a0)
+    aux = one(a0^r)
+    a[0] = aux * a0
+    r == 0.5 && return sqrt(a)
+    a_order = get_order(a)
+    if TS._isthinzero(a0)
+        throw(DomainError(a,
+            """The 0-th order TaylorN coefficient must be non-zero
+            in order to expand `^` around 0."""))
+    end
+    c = TaylorN(zero(aux), a_order)
+    aux0 = zero(c)
+    for k in eachindex(c)
+        TS.pow!(c, a, aux0, r, k)
+    end
+    return c
 end
 
 # sqr!
-for T = (:Taylor1, :TaylorN)
-    @eval begin
-        function TS.sqr!(c::$T{Interval{T}}, a::$T{Interval{T}},
-                ::Interval{T}, k::Int) where {T<:NumTypes}
-            if k == 0
-                TS.sqr_orderzero!(c, a)
-                return nothing
-            end
-            # Sanity
-            TS.zero!(c, k)
-            # Recursion formula
-            kodd = k%2
-            kend = div(k - 2 + kodd, 2)
-            if $T == Taylor1
-                @inbounds for i = 0:kend
-                    c[k] += a[i] * a[k-i]
-                end
-            else
-                @inbounds for i = 0:kend
-                    TS.mul!(c[k], a[i], a[k-i])
-                end
-            end
-            @inbounds TS.mul!(c, interval(T(2)), c, k)
-            kodd == 1 && return nothing
-            if $T == Taylor1
-                @inbounds c[k] += a[k >> 1]^2
-            else
-                TS.accsqr!(c[k], a[k >> 1])
-            end
-            return nothing
-        end
-
-        function TS.sqr!(c::$T{Interval{T}}, k::Int) where {T<:NumTypes}
-            if k == 0
-                TS.sqr_orderzero!(c, c)
-                return nothing
-            end
-            # Recursion formula
-            kodd = k%2
-            kend = (k - 2 + kodd) >> 1
-            if $T == Taylor1
-                (kend ≥ 0) && ( @inbounds c[k] = c[0] * c[k] )
-                @inbounds for i = 1:kend
-                    c[k] += c[i] * c[k-i]
-                end
-                @inbounds c[k] = interval(T(2)) * c[k]
-                (kodd == 0) && ( @inbounds c[k] += c[k >> 1]^2 )
-            else
-                (kend ≥ 0) && ( @inbounds TS.mul!(c, c[0][1], c, k) )
-                @inbounds for i = 1:kend
-                    TS.mul!(c[k], c[i], c[k-i])
-                end
-                @inbounds TS.mul!(c, interval(T(2)), c, k)
-                if (kodd == 0)
-                    TS.accsqr!(c[k], c[k >> 1])
-                end
-            end
-
-            return nothing
-        end
+function TS.sqr!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}},
+        ::Interval{T}, k::Int) where {T<:NumTypes}
+    if k == 0
+        TS.sqr_orderzero!(c, a)
+        return nothing
     end
+    # Sanity
+    TS.zero!(c, k)
+    # Recursion formula
+    kodd = k%2
+    kend = div(k - 2 + kodd, 2)
+    @inbounds for i = 0:kend
+        c[k] += a[i] * a[k-i]
+    end
+    @inbounds TS.mul!(c, interval(T(2)), c, k)
+    kodd == 1 && return nothing
+    @inbounds c[k] += a[k >> 1]^2
+    return nothing
 end
+
+function TS.sqr!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}},
+        ::Interval{T}, k::Int) where {T<:NumTypes}
+    if k == 0
+        TS.sqr_orderzero!(c, a)
+        return nothing
+    end
+    # Sanity
+    TS.zero!(c, k)
+    # Recursion formula
+    kodd = k%2
+    kend = div(k - 2 + kodd, 2)
+    @inbounds for i = 0:kend
+        TS.mul!(c[k], a[i], a[k-i])
+    end
+    @inbounds TS.mul!(c, interval(T(2)), c, k)
+    kodd == 1 && return nothing
+    TS.accsqr!(c[k], a[k >> 1])
+    return nothing
+end
+
+function TS.sqr!(c::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        TS.sqr_orderzero!(c, c)
+        return nothing
+    end
+    # Recursion formula
+    kodd = k%2
+    kend = (k - 2 + kodd) >> 1
+    (kend >= 0) && ( @inbounds c[k] = c[0] * c[k] )
+    @inbounds for i = 1:kend
+        c[k] += c[i] * c[k-i]
+    end
+    @inbounds c[k] = interval(T(2)) * c[k]
+    (kodd == 0) && ( @inbounds c[k] += c[k >> 1]^2 )
+    return nothing
+end
+
+function TS.sqr!(c::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        TS.sqr_orderzero!(c, c)
+        return nothing
+    end
+    # Recursion formula
+    kodd = k%2
+    kend = (k - 2 + kodd) >> 1
+    (kend >= 0) && ( @inbounds TS.mul!(c, c[0][1], c, k) )
+    @inbounds for i = 1:kend
+        TS.mul!(c[k], c[i], c[k-i])
+    end
+    @inbounds TS.mul!(c, interval(T(2)), c, k)
+    if (kodd == 0)
+        TS.accsqr!(c[k], c[k >> 1])
+    end
+    return nothing
+end
+
 function TS.accsqr!(c::HomogeneousPolynomial{Interval{T}},
         a::HomogeneousPolynomial{Interval{T}}) where {T<:NumTypes}
     iszero(a) && return nothing
@@ -425,376 +458,482 @@ for T in (:Taylor1, :TaylorN)
             return c
         end
 
-        # Some internal functions
-        function TS.exp!(c::$T{Interval{T}}, a::$T{Interval{T}}, k::Int) where {T<:NumTypes}
-            if k == 0
-                @inbounds c[0] = exp(constant_term(a))
-                return nothing
-            end
-            if $T == Taylor1
-                @inbounds c[k] = interval(T(k)) * a[k] * c[0]
-            else
-                @inbounds TS.mul!(c[k], interval(T(k)) * a[k], c[0])
-            end
-            @inbounds for i = 1:k-1
-                if $T == Taylor1
-                    c[k] += interval(T(k-i)) * a[k-i] * c[i]
-                else
-                    TS.mul!(c[k], interval(T(k-i)) * a[k-i], c[i])
-                end
-            end
-            @inbounds c[k] = c[k] / interval(T(k))
-            return nothing
-        end
-
-        function TS.expm1!(c::$T{Interval{T}}, a::$T{Interval{T}}, k::Int) where {T<:NumTypes}
-            if k == 0
-                @inbounds c[0] = expm1(constant_term(a))
-                return nothing
-            end
-            c0 = c[0]+one(c[0])
-            if $T == Taylor1
-                @inbounds c[k] = interval(T(k)) * a[k] * c0
-            else
-                @inbounds TS.mul!(c[k], interval(T(k)) * a[k], c0)
-            end
-            @inbounds for i = 1:k-1
-                if $T == Taylor1
-                    c[k] += interval(T(k-i)) * a[k-i] * c[i]
-                else
-                    TS.mul!(c[k], interval(T(k-i)) * a[k-i], c[i])
-                end
-            end
-            @inbounds c[k] = c[k] / interval(T(k))
-            return nothing
-        end
-
-        function TS.log!(c::$T{Interval{T}}, a::$T{Interval{T}}, k::Int) where {T<:NumTypes}
-            if k == 0
-                @inbounds c[0] = log(constant_term(a))
-                return nothing
-            elseif k == 1
-                @inbounds c[1] = a[1] / constant_term(a)
-                return nothing
-            end
-            if $T == Taylor1
-                @inbounds c[k] = interval(T(k-1)) * a[1] * c[k-1]
-            else
-                @inbounds TS.mul!(c[k], interval(T(k-1))*a[1], c[k-1])
-            end
-            @inbounds for i = 2:k-1
-                if $T == Taylor1
-                    c[k] += interval(T(k-i)) * a[i] * c[k-i]
-                else
-                    TS.mul!(c[k], interval(T(k-i))*a[i], c[k-i])
-                end
-            end
-            @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(a)
-            return nothing
-        end
-
-        function TS.log1p!(c::$T{Interval{T}}, a::$T{Interval{T}}, k::Int) where {T<:NumTypes}
-            a0 = constant_term(a)
-            a0p1 = a0+one(a0)
-            if k == 0
-                @inbounds c[0] = log1p(a0)
-                return nothing
-            elseif k == 1
-                @inbounds c[1] = a[1] / a0p1
-                return nothing
-            end
-            if $T == Taylor1
-                @inbounds c[k] = interval(T(k-1)) * a[1] * c[k-1]
-            else
-                @inbounds TS.mul!(c[k], interval(T(k-1))*a[1], c[k-1])
-            end
-            @inbounds for i = 2:k-1
-                if $T == Taylor1
-                    c[k] += interval(T(k-i)) * a[i] * c[k-i]
-                else
-                    TS.mul!(c[k], interval(T(k-i))*a[i], c[k-i])
-                end
-            end
-            @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / a0p1
-            return nothing
-        end
-
-        function TS.sincos!(s::$T{Interval{T}}, c::$T{Interval{T}}, a::$T{Interval{T}},
-                k::Int) where {T<:NumTypes}
-            if k == 0
-                a0 = constant_term(a)
-                @inbounds s[0], c[0] = sincos( a0 )
-                return nothing
-            end
-            x = a[1]
-            if $T == Taylor1
-                @inbounds s[k] = x * c[k-1]
-                @inbounds c[k] = -x * s[k-1]
-            else
-                TS.mul!(s[k], x, c[k-1])
-                TS.mul!(c[k], -x, s[k-1])
-            end
-            @inbounds for i = 2:k
-                x = interval(T(i)) * a[i]
-                if $T == Taylor1
-                    s[k] += x * c[k-i]
-                    c[k] -= x * s[k-i]
-                else
-                    TS.mul!(s[k], x, c[k-i])
-                    TS.mul!(c[k], -x, s[k-i])
-                end
-            end
-            @inbounds s[k] = s[k] / interval(T(k))
-            @inbounds c[k] = c[k] / interval(T(k))
-            return nothing
-        end
-
-        function TS.tan!(c::$T{Interval{T}}, a::$T{Interval{T}}, c2::$T{Interval{T}},
-                k::Int) where {T<:NumTypes}
-            if k == 0
-                @inbounds aux = tan( constant_term(a) )
-                @inbounds c[0] = aux
-                @inbounds c2[0] = aux^2
-                return nothing
-            end
-            if $T == Taylor1
-                @inbounds c[k] = interval(T(k)) * a[k] * c2[0]
-            else
-                @inbounds TS.mul!(c[k], interval(T(k)) * a[k], c2[0])
-            end
-            @inbounds for i = 1:k-1
-                if $T == Taylor1
-                    c[k] += interval(T(k-i)) * a[k-i] * c2[i]
-                else
-                    TS.mul!(c[k], interval(T(k-i)) * a[k-i], c2[i])
-                end
-            end
-            @inbounds c[k] = a[k] + c[k]/interval(T(k))
-            if $T == Taylor1
-                TS.sqr!(c2, c, zero(c[0]), k)
-            else
-                TS.sqr!(c2, c, zero(c[0][1]), k)
-            end
-            return nothing
-        end
-
-        function TS.asin!(c::$T{Interval{T}}, a::$T{Interval{T}}, r::$T{Interval{T}},
-                k::Int) where {T<:NumTypes}
-            a0 = constant_term(a)
-            if k == 0
-                @inbounds c[0] = asin( a0 )
-                @inbounds r[0] = sqrt( one(a0) - a0^2 )
-                return nothing
-            end
-            if $T == Taylor1
-                @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
-            else
-                @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
-            end
-            @inbounds for i in 2:k-1
-                if $T == Taylor1
-                    c[k] += interval(T(k-i)) * r[i] * c[k-i]
-                else
-                    TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
-                end
-            end
-            TS.sqrt!(r, one(a[0])-a^2, zero(a0), k)
-            @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
-            return nothing
-        end
-
-        function TS.acos!(c::$T{Interval{T}}, a::$T{Interval{T}}, r::$T{Interval{T}},
-                k::Int) where {T<:NumTypes}
-            a0 = constant_term(a)
-            if k == 0
-                @inbounds c[0] = acos( a0 )
-                @inbounds r[0] = sqrt( one(a0) - a0^2 )
-                return nothing
-            end
-            if $T == Taylor1
-                @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
-            else
-                @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
-            end
-            @inbounds for i in 2:k-1
-                if $T == Taylor1
-                    c[k] += interval(T(k-i)) * r[i] * c[k-i]
-                else
-                    TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
-                end
-            end
-            TS.sqrt!(r, one(a[0])-a^2, zero(a0), k)
-            @inbounds c[k] = -(a[k] + c[k]/interval(T(k))) / constant_term(r)
-            return nothing
-        end
-
-        function TS.atan!(c::$T{Interval{T}}, a::$T{Interval{T}}, r::$T{Interval{T}},
-                k::Int) where {T<:NumTypes}
-            if k == 0
-                a0 = constant_term(a)
-                @inbounds c[0] = atan( a0 )
-                @inbounds r[0] = one(a0) + a0^2
-                return nothing
-            end
-            if $T == Taylor1
-                @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
-            else
-                @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
-            end
-            @inbounds for i in 2:k-1
-                if $T == Taylor1
-                    c[k] += interval(T(k-i)) * r[i] * c[k-i]
-                else
-                    TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
-                end
-            end
-            if $T == Taylor1
-                TS.sqr!(r, a, zero(a[0]), k)
-            else
-                TS.sqr!(r, a, zero(a[0][1]), k)
-            end
-            @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
-            return nothing
-        end
-
-        function TS.sinhcosh!(s::$T{Interval{T}}, c::$T{Interval{T}}, a::$T{Interval{T}},
-                k::Int) where {T<:NumTypes}
-            if k == 0
-                @inbounds s[0] = sinh( constant_term(a) )
-                @inbounds c[0] = cosh( constant_term(a) )
-                return nothing
-            end
-            x = a[1]
-            if $T == Taylor1
-                @inbounds s[k] = x * c[k-1]
-                @inbounds c[k] = x * s[k-1]
-            else
-                @inbounds TS.mul!(s[k], x, c[k-1])
-                @inbounds TS.mul!(c[k], x, s[k-1])
-            end
-            @inbounds for i = 2:k
-                x = interval(T(i)) * a[i]
-                if $T == Taylor1
-                    s[k] += x * c[k-i]
-                    c[k] += x * s[k-i]
-                else
-                    TS.mul!(s[k], x, c[k-i])
-                    TS.mul!(c[k], x, s[k-i])
-                end
-            end
-            s[k] = s[k] / interval(T(k))
-            c[k] = c[k] / interval(T(k))
-            return nothing
-        end
-
-        function TS.tanh!(c::$T{Interval{T}}, a::$T{Interval{T}}, c2::$T{Interval{T}},
-                k::Int) where {T<:NumTypes}
-            if k == 0
-                @inbounds aux = tanh( constant_term(a) )
-                @inbounds c[0] = aux
-                @inbounds c2[0] = aux^2
-                return nothing
-            end
-            if $T == Taylor1
-                @inbounds c[k] = k * a[k] * c2[0]
-            else
-                @inbounds TS.mul!(c[k], k * a[k], c2[0])
-            end
-            @inbounds for i = 1:k-1
-                if $T == Taylor1
-                    c[k] += (k-i) * a[k-i] * c2[i]
-                else
-                    TS.mul!(c[k], (k-i) * a[k-i], c2[i])
-                end
-            end
-            @inbounds c[k] = a[k] - c[k]/k
-            if $T == Taylor1
-                TS.sqr!(c2, c, zero(c[0]), k)
-            else
-                TS.sqr!(c2, c, zero(c[0][1]), k)
-            end
-            return nothing
-        end
-
-        function TS.asinh!(c::$T{Interval{T}}, a::$T{Interval{T}}, r::$T{Interval{T}},
-                k::Int) where {T<:NumTypes}
-            a0 = constant_term(a)
-            if k == 0
-                @inbounds c[0] = asinh( a0 )
-                @inbounds r[0] = sqrt( a0^2 + one(a0) )
-                return nothing
-            end
-            if $T == Taylor1
-                @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
-            else
-                @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
-            end
-            @inbounds for i in 2:k-1
-                if $T == Taylor1
-                    c[k] += interval(T(k-i)) * r[i] * c[k-i]
-                else
-                    TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
-                end
-            end
-            TS.sqrt!(r, a^2+one(a[0]), zero(a0), k)
-            @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
-            return nothing
-        end
-
-        function TS.acosh!(c::$T{Interval{T}}, a::$T{Interval{T}}, r::$T{Interval{T}},
-                k::Int) where {T<:NumTypes}
-            a0 = constant_term(a)
-            if k == 0
-                @inbounds c[0] = acosh( a0 )
-                @inbounds r[0] = sqrt( a0^2 - one(a0) )
-                return nothing
-            end
-            if $T == Taylor1
-                @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
-            else
-                @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
-            end
-            @inbounds for i in 2:k-1
-                if $T == Taylor1
-                    c[k] += interval(T(k-i)) * r[i] * c[k-i]
-                else
-                    TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
-                end
-            end
-            TS.sqrt!(r, a^2-one(a[0]), zero(a0), k)
-            @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
-            return nothing
-        end
-
-        function TS.atanh!(c::$T{Interval{T}}, a::$T{Interval{T}}, r::$T{Interval{T}},
-                k::Int) where {T<:NumTypes}
-            a0 = constant_term(a)
-            if k == 0
-                @inbounds c[0] = atanh( a0 )
-                @inbounds r[0] = one(a0) - a0^2
-                return nothing
-            end
-            if $T == Taylor1
-                @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
-            else
-                @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
-            end
-            @inbounds for i in 2:k-1
-                if $T == Taylor1
-                    c[k] += interval(T(k-i)) * r[i] * c[k-i]
-                else
-                    TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
-                end
-            end
-            if $T == Taylor1
-                TS.sqr!(r, a, zero(a0), k)
-            else
-                TS.sqr!(r, a, zero(a0), k)
-            end
-            @inbounds c[k] = (a[k] + c[k]/interval(T(k))) / constant_term(r)
-            return nothing
-        end
     end
+end
+
+# Some internal functions
+function TS.exp!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds c[0] = exp(constant_term(a))
+        return nothing
+    end
+    @inbounds c[k] = interval(T(k)) * a[k] * c[0]
+    @inbounds for i = 1:k-1
+        c[k] += interval(T(k-i)) * a[k-i] * c[i]
+    end
+    @inbounds c[k] = c[k] / interval(T(k))
+    return nothing
+end
+
+function TS.exp!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds c[0] = exp(constant_term(a))
+        return nothing
+    end
+    @inbounds TS.mul!(c[k], interval(T(k)) * a[k], c[0])
+    @inbounds for i = 1:k-1
+        TS.mul!(c[k], interval(T(k-i)) * a[k-i], c[i])
+    end
+    @inbounds c[k] = c[k] / interval(T(k))
+    return nothing
+end
+
+function TS.expm1!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds c[0] = expm1(constant_term(a))
+        return nothing
+    end
+    c0 = c[0]+one(c[0])
+    @inbounds c[k] = interval(T(k)) * a[k] * c0
+    @inbounds for i = 1:k-1
+        c[k] += interval(T(k-i)) * a[k-i] * c[i]
+    end
+    @inbounds c[k] = c[k] / interval(T(k))
+    return nothing
+end
+
+function TS.expm1!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds c[0] = expm1(constant_term(a))
+        return nothing
+    end
+    c0 = c[0]+one(c[0])
+    @inbounds TS.mul!(c[k], interval(T(k)) * a[k], c0)
+    @inbounds for i = 1:k-1
+        TS.mul!(c[k], interval(T(k-i)) * a[k-i], c[i])
+    end
+    @inbounds c[k] = c[k] / interval(T(k))
+    return nothing
+end
+
+function TS.log!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds c[0] = log(constant_term(a))
+        return nothing
+    elseif k == 1
+        @inbounds c[1] = a[1] / constant_term(a)
+        return nothing
+    end
+    @inbounds c[k] = interval(T(k-1)) * a[1] * c[k-1]
+    @inbounds for i = 2:k-1
+        c[k] += interval(T(k-i)) * a[i] * c[k-i]
+    end
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(a)
+    return nothing
+end
+
+function TS.log!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds c[0] = log(constant_term(a))
+        return nothing
+    elseif k == 1
+        @inbounds c[1] = a[1] / constant_term(a)
+        return nothing
+    end
+    @inbounds TS.mul!(c[k], interval(T(k-1))*a[1], c[k-1])
+    @inbounds for i = 2:k-1
+        TS.mul!(c[k], interval(T(k-i))*a[i], c[k-i])
+    end
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(a)
+    return nothing
+end
+
+function TS.log1p!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    a0p1 = a0+one(a0)
+    if k == 0
+        @inbounds c[0] = log1p(a0)
+        return nothing
+    elseif k == 1
+        @inbounds c[1] = a[1] / a0p1
+        return nothing
+    end
+    @inbounds c[k] = interval(T(k-1)) * a[1] * c[k-1]
+    @inbounds for i = 2:k-1
+        c[k] += interval(T(k-i)) * a[i] * c[k-i]
+    end
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / a0p1
+    return nothing
+end
+
+function TS.log1p!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    a0p1 = a0+one(a0)
+    if k == 0
+        @inbounds c[0] = log1p(a0)
+        return nothing
+    elseif k == 1
+        @inbounds c[1] = a[1] / a0p1
+        return nothing
+    end
+    @inbounds TS.mul!(c[k], interval(T(k-1))*a[1], c[k-1])
+    @inbounds for i = 2:k-1
+        TS.mul!(c[k], interval(T(k-i))*a[i], c[k-i])
+    end
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / a0p1
+    return nothing
+end
+
+function TS.sincos!(s::Taylor1{Interval{T}}, c::Taylor1{Interval{T}},
+        a::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        a0 = constant_term(a)
+        @inbounds s[0], c[0] = sincos( a0 )
+        return nothing
+    end
+    x = a[1]
+    @inbounds s[k] = x * c[k-1]
+    @inbounds c[k] = -x * s[k-1]
+    @inbounds for i = 2:k
+        x = interval(T(i)) * a[i]
+        s[k] += x * c[k-i]
+        c[k] -= x * s[k-i]
+    end
+    @inbounds s[k] = s[k] / interval(T(k))
+    @inbounds c[k] = c[k] / interval(T(k))
+    return nothing
+end
+
+function TS.sincos!(s::TaylorN{Interval{T}}, c::TaylorN{Interval{T}},
+        a::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        a0 = constant_term(a)
+        @inbounds s[0], c[0] = sincos( a0 )
+        return nothing
+    end
+    x = a[1]
+    TS.mul!(s[k], x, c[k-1])
+    TS.mul!(c[k], -x, s[k-1])
+    @inbounds for i = 2:k
+        x = interval(T(i)) * a[i]
+        TS.mul!(s[k], x, c[k-i])
+        TS.mul!(c[k], -x, s[k-i])
+    end
+    @inbounds s[k] = s[k] / interval(T(k))
+    @inbounds c[k] = c[k] / interval(T(k))
+    return nothing
+end
+
+function TS.tan!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}},
+        c2::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds aux = tan( constant_term(a) )
+        @inbounds c[0] = aux
+        @inbounds c2[0] = aux^2
+        return nothing
+    end
+    @inbounds c[k] = interval(T(k)) * a[k] * c2[0]
+    @inbounds for i = 1:k-1
+        c[k] += interval(T(k-i)) * a[k-i] * c2[i]
+    end
+    @inbounds c[k] = a[k] + c[k]/interval(T(k))
+    TS.sqr!(c2, c, zero(c[0]), k)
+    return nothing
+end
+
+function TS.tan!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}},
+        c2::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds aux = tan( constant_term(a) )
+        @inbounds c[0] = aux
+        @inbounds c2[0] = aux^2
+        return nothing
+    end
+    @inbounds TS.mul!(c[k], interval(T(k)) * a[k], c2[0])
+    @inbounds for i = 1:k-1
+        TS.mul!(c[k], interval(T(k-i)) * a[k-i], c2[i])
+    end
+    @inbounds c[k] = a[k] + c[k]/interval(T(k))
+    TS.sqr!(c2, c, zero(c[0][1]), k)
+    return nothing
+end
+
+function TS.asin!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}},
+        r::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    if k == 0
+        @inbounds c[0] = asin( a0 )
+        @inbounds r[0] = sqrt( one(a0) - a0^2 )
+        return nothing
+    end
+    @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
+    @inbounds for i in 2:k-1
+        c[k] += interval(T(k-i)) * r[i] * c[k-i]
+    end
+    TS.sqrt!(r, one(a[0])-a^2, zero(a0), k)
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
+    return nothing
+end
+
+function TS.asin!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}},
+        r::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    if k == 0
+        @inbounds c[0] = asin( a0 )
+        @inbounds r[0] = sqrt( one(a0) - a0^2 )
+        return nothing
+    end
+    @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
+    @inbounds for i in 2:k-1
+        TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
+    end
+    TS.sqrt!(r, one(a[0])-a^2, zero(a0), k)
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
+    return nothing
+end
+
+function TS.acos!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}},
+        r::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    if k == 0
+        @inbounds c[0] = acos( a0 )
+        @inbounds r[0] = sqrt( one(a0) - a0^2 )
+        return nothing
+    end
+    @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
+    @inbounds for i in 2:k-1
+        c[k] += interval(T(k-i)) * r[i] * c[k-i]
+    end
+    TS.sqrt!(r, one(a[0])-a^2, zero(a0), k)
+    @inbounds c[k] = -(a[k] + c[k]/interval(T(k))) / constant_term(r)
+    return nothing
+end
+
+function TS.acos!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}},
+        r::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    if k == 0
+        @inbounds c[0] = acos( a0 )
+        @inbounds r[0] = sqrt( one(a0) - a0^2 )
+        return nothing
+    end
+    @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
+    @inbounds for i in 2:k-1
+        TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
+    end
+    TS.sqrt!(r, one(a[0])-a^2, zero(a0), k)
+    @inbounds c[k] = -(a[k] + c[k]/interval(T(k))) / constant_term(r)
+    return nothing
+end
+
+function TS.atan!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}},
+        r::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        a0 = constant_term(a)
+        @inbounds c[0] = atan( a0 )
+        @inbounds r[0] = one(a0) + a0^2
+        return nothing
+    end
+    @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
+    @inbounds for i in 2:k-1
+        c[k] += interval(T(k-i)) * r[i] * c[k-i]
+    end
+    TS.sqr!(r, a, zero(a[0]), k)
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
+    return nothing
+end
+
+function TS.atan!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}},
+        r::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        a0 = constant_term(a)
+        @inbounds c[0] = atan( a0 )
+        @inbounds r[0] = one(a0) + a0^2
+        return nothing
+    end
+    @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
+    @inbounds for i in 2:k-1
+        TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
+    end
+    TS.sqr!(r, a, zero(a[0][1]), k)
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
+    return nothing
+end
+
+function TS.sinhcosh!(s::Taylor1{Interval{T}}, c::Taylor1{Interval{T}},
+        a::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds s[0] = sinh( constant_term(a) )
+        @inbounds c[0] = cosh( constant_term(a) )
+        return nothing
+    end
+    x = a[1]
+    @inbounds s[k] = x * c[k-1]
+    @inbounds c[k] = x * s[k-1]
+    @inbounds for i = 2:k
+        x = interval(T(i)) * a[i]
+        s[k] += x * c[k-i]
+        c[k] += x * s[k-i]
+    end
+    s[k] = s[k] / interval(T(k))
+    c[k] = c[k] / interval(T(k))
+    return nothing
+end
+
+function TS.sinhcosh!(s::TaylorN{Interval{T}}, c::TaylorN{Interval{T}},
+        a::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds s[0] = sinh( constant_term(a) )
+        @inbounds c[0] = cosh( constant_term(a) )
+        return nothing
+    end
+    x = a[1]
+    @inbounds TS.mul!(s[k], x, c[k-1])
+    @inbounds TS.mul!(c[k], x, s[k-1])
+    @inbounds for i = 2:k
+        x = interval(T(i)) * a[i]
+        TS.mul!(s[k], x, c[k-i])
+        TS.mul!(c[k], x, s[k-i])
+    end
+    s[k] = s[k] / interval(T(k))
+    c[k] = c[k] / interval(T(k))
+    return nothing
+end
+
+function TS.tanh!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}},
+        c2::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds aux = tanh( constant_term(a) )
+        @inbounds c[0] = aux
+        @inbounds c2[0] = aux^2
+        return nothing
+    end
+    @inbounds c[k] = k * a[k] * c2[0]
+    @inbounds for i = 1:k-1
+        c[k] += (k-i) * a[k-i] * c2[i]
+    end
+    @inbounds c[k] = a[k] - c[k]/k
+    TS.sqr!(c2, c, zero(c[0]), k)
+    return nothing
+end
+
+function TS.tanh!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}},
+        c2::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    if k == 0
+        @inbounds aux = tanh( constant_term(a) )
+        @inbounds c[0] = aux
+        @inbounds c2[0] = aux^2
+        return nothing
+    end
+    @inbounds TS.mul!(c[k], k * a[k], c2[0])
+    @inbounds for i = 1:k-1
+        TS.mul!(c[k], (k-i) * a[k-i], c2[i])
+    end
+    @inbounds c[k] = a[k] - c[k]/k
+    TS.sqr!(c2, c, zero(c[0][1]), k)
+    return nothing
+end
+
+function TS.asinh!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}},
+        r::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    if k == 0
+        @inbounds c[0] = asinh( a0 )
+        @inbounds r[0] = sqrt( a0^2 + one(a0) )
+        return nothing
+    end
+    @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
+    @inbounds for i in 2:k-1
+        c[k] += interval(T(k-i)) * r[i] * c[k-i]
+    end
+    TS.sqrt!(r, a^2+one(a[0]), zero(a0), k)
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
+    return nothing
+end
+
+function TS.asinh!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}},
+        r::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    if k == 0
+        @inbounds c[0] = asinh( a0 )
+        @inbounds r[0] = sqrt( a0^2 + one(a0) )
+        return nothing
+    end
+    @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
+    @inbounds for i in 2:k-1
+        TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
+    end
+    TS.sqrt!(r, a^2+one(a[0]), zero(a0), k)
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
+    return nothing
+end
+
+function TS.acosh!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}},
+        r::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    if k == 0
+        @inbounds c[0] = acosh( a0 )
+        @inbounds r[0] = sqrt( a0^2 - one(a0) )
+        return nothing
+    end
+    @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
+    @inbounds for i in 2:k-1
+        c[k] += interval(T(k-i)) * r[i] * c[k-i]
+    end
+    TS.sqrt!(r, a^2-one(a[0]), zero(a0), k)
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
+    return nothing
+end
+
+function TS.acosh!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}},
+        r::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    if k == 0
+        @inbounds c[0] = acosh( a0 )
+        @inbounds r[0] = sqrt( a0^2 - one(a0) )
+        return nothing
+    end
+    @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
+    @inbounds for i in 2:k-1
+        TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
+    end
+    TS.sqrt!(r, a^2-one(a[0]), zero(a0), k)
+    @inbounds c[k] = (a[k] - c[k]/interval(T(k))) / constant_term(r)
+    return nothing
+end
+
+function TS.atanh!(c::Taylor1{Interval{T}}, a::Taylor1{Interval{T}},
+        r::Taylor1{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    if k == 0
+        @inbounds c[0] = atanh( a0 )
+        @inbounds r[0] = one(a0) - a0^2
+        return nothing
+    end
+    @inbounds c[k] = interval(T(k-1)) * r[1] * c[k-1]
+    @inbounds for i in 2:k-1
+        c[k] += interval(T(k-i)) * r[i] * c[k-i]
+    end
+    TS.sqr!(r, a, zero(a0), k)
+    @inbounds c[k] = (a[k] + c[k]/interval(T(k))) / constant_term(r)
+    return nothing
+end
+
+function TS.atanh!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}},
+        r::TaylorN{Interval{T}}, k::Int) where {T<:NumTypes}
+    a0 = constant_term(a)
+    if k == 0
+        @inbounds c[0] = atanh( a0 )
+        @inbounds r[0] = one(a0) - a0^2
+        return nothing
+    end
+    @inbounds TS.mul!(c[k], interval(T(k-1)) * r[1], c[k-1])
+    @inbounds for i in 2:k-1
+        TS.mul!(c[k], interval(T(k-i)) * r[i], c[k-i])
+    end
+    TS.sqr!(r, a, zero(a0), k)
+    @inbounds c[k] = (a[k] + c[k]/interval(T(k))) / constant_term(r)
+    return nothing
 end
 
 

--- a/ext/TaylorSeriesIAExt.jl
+++ b/ext/TaylorSeriesIAExt.jl
@@ -183,7 +183,7 @@ function TS.sqr!(c::TaylorN{Interval{T}}, a::TaylorN{Interval{T}},
     TS.zero!(c, k)
     # Recursion formula
     kodd = k%2
-    kend = div(k - 2 + kodd, 2)
+    kend = (k - 2 + kodd) >> 1
     @inbounds for i = 0:kend
         TS.mul!(c[k], a[i], a[k-i])
     end

--- a/src/power.jl
+++ b/src/power.jl
@@ -246,7 +246,8 @@ function pow!(c::Taylor1{T}, a::Taylor1{T}, aux::Taylor1{T},
     for i = 1:k-lnull-1
         ((i+lnull) > get_order(a) || (l0+kprime-i > get_order(a))) && continue
         aux = r*(kprime-i) - i
-        @inbounds c[k] += aux * c[i+lnull] * a[l0+kprime-i]
+aaux = r*(kprime-i) - i
+@inbounds c[k] += aaux * c[i+lnull] * a[l0+kprime-i]
     end
     @inbounds c[k] = c[k] / (kprime * a[l0])
     return nothing

--- a/src/power.jl
+++ b/src/power.jl
@@ -245,9 +245,8 @@ function pow!(c::Taylor1{T}, a::Taylor1{T}, aux::Taylor1{T},
     end
     for i = 1:k-lnull-1
         ((i+lnull) > get_order(a) || (l0+kprime-i > get_order(a))) && continue
-        aux = r*(kprime-i) - i
-aaux = r*(kprime-i) - i
-@inbounds c[k] += aaux * c[i+lnull] * a[l0+kprime-i]
+        aaux = r*(kprime-i) - i
+        @inbounds c[k] += aaux * c[i+lnull] * a[l0+kprime-i]
     end
     @inbounds c[k] = c[k] / (kprime * a[l0])
     return nothing

--- a/src/power.jl
+++ b/src/power.jl
@@ -38,27 +38,32 @@ end
 
 
 ## Real power ##
-for T in (:Taylor1, :TaylorN)
-    @eval function ^(a::$T{T}, r::S) where {T<:Number, S<:Real}
-        a0 = constant_term(a)
-        aux = a0^zero(r)
-        iszero(r) && return $T(aux, get_order(a))
-        aa = aux*a
-        r == 1 && return aa
-        r == 2 && return square(aa)
-        if $T == TaylorN
-            isinteger(r) && r ≥ 0 && return power_by_squaring(a, Integer(r))
-        end
-        r == 0.5 && return sqrt(aa)
-        if $T == TaylorN
-            if iszero(a0)
-                throw(DomainError(a,
-                """The 0-th order TaylorN coefficient must be non-zero
-                in order to expand `^` around 0."""))
-            end
-        end
-        return _pow(aa, r)
+function ^(a::Taylor1{T}, r::S) where {T<:Number, S<:Real}
+    a0 = constant_term(a)
+    aux = a0^zero(r)
+    iszero(r) && return Taylor1(aux, get_order(a))
+    aa = aux*a
+    r == 1 && return aa
+    r == 2 && return square(aa)
+    r == 0.5 && return sqrt(aa)
+    return _pow(aa, r)
+end
+
+function ^(a::TaylorN{T}, r::S) where {T<:Number, S<:Real}
+    a0 = constant_term(a)
+    aux = a0^zero(r)
+    iszero(r) && return TaylorN(aux, get_order(a))
+    aa = aux*a
+    r == 1 && return aa
+    r == 2 && return square(aa)
+    isinteger(r) && r >= 0 && return power_by_squaring(a, Integer(r))
+    r == 0.5 && return sqrt(aa)
+    if iszero(a0)
+        throw(DomainError(a,
+        """The 0-th order TaylorN coefficient must be non-zero
+        in order to expand `^` around 0."""))
     end
+    return _pow(aa, r)
 end
 
 
@@ -477,68 +482,79 @@ c_k &= 2 \sum_{j=0}^{(k-2)/2} a_{k-j} a_j + (a_{k/2})^2,
 
 """ sqr!
 
-for T = (:Taylor1, :TaylorN)
-    @eval begin
-        function sqr!(c::$T{T}, a::$T{T}, ::T, k::Int) where {T<:Number}
-            if k == 0
-                sqr_orderzero!(c, a)
-                return nothing
-            end
-            # Sanity
-            zero!(c, k)
-            # Recursion formula
-            kodd = k%2
-            kend = (k - 2 + kodd) >> 1
-            if $T == Taylor1
-                @inbounds for i = 0:kend
-                    c[k] += a[i] * a[k-i]
-                end
-                @inbounds c[k] = 2 * c[k]
-            else
-                @inbounds for i = 0:kend
-                    mul!(c[k], a[i], a[k-i])
-                end
-                @inbounds mul!(c, 2, c, k)
-            end
-            kodd == 1 && return nothing
-            if $T == Taylor1
-                @inbounds c[k] += a[k >> 1]^2
-            else
-                accsqr!(c[k], a[k >> 1])
-            end
-
-            return nothing
-        end
-
-        # in-place squaring: given `c`, compute expansion of `c^2` and save back into `c`
-        function sqr!(c::$T{T}, k::Int) where {T<:NumberNotSeries}
-            if k == 0
-                sqr_orderzero!(c, c)
-                return nothing
-            end
-            # Recursion formula
-            kodd = k%2
-            kend = (k - 2 + kodd) >> 1
-            if $T == Taylor1
-                (kend ≥ 0) && ( @inbounds c[k] = c[0] * c[k] )
-                @inbounds for i = 1:kend
-                    c[k] += c[i] * c[k-i]
-                end
-                @inbounds c[k] = 2 * c[k]
-                (kodd == 0) && ( @inbounds c[k] += c[k >> 1]^2 )
-            else
-                (kend ≥ 0) && ( @inbounds mul!(c, c[0][1], c, k) )
-                @inbounds for i = 1:kend
-                    mul!(c[k], c[i], c[k-i])
-                end
-                @inbounds mul!(c, 2, c, k)
-                if (kodd == 0)
-                    accsqr!(c[k], c[k >> 1])
-                end
-            end
-            return nothing
-        end
+function sqr!(c::Taylor1{T}, a::Taylor1{T}, ::T, k::Int) where {T<:Number}
+    if k == 0
+        sqr_orderzero!(c, a)
+        return nothing
     end
+    # Sanity
+    zero!(c, k)
+    # Recursion formula
+    kodd = k%2
+    kend = (k - 2 + kodd) >> 1
+    @inbounds for i = 0:kend
+        c[k] += a[i] * a[k-i]
+    end
+    @inbounds c[k] = 2 * c[k]
+    kodd == 1 && return nothing
+    @inbounds c[k] += a[k >> 1]^2
+    return nothing
+end
+
+function sqr!(c::TaylorN{T}, a::TaylorN{T}, ::T, k::Int) where {T<:Number}
+    if k == 0
+        sqr_orderzero!(c, a)
+        return nothing
+    end
+    # Sanity
+    zero!(c, k)
+    # Recursion formula
+    kodd = k%2
+    kend = (k - 2 + kodd) >> 1
+    @inbounds for i = 0:kend
+        mul!(c[k], a[i], a[k-i])
+    end
+    @inbounds mul!(c, 2, c, k)
+    kodd == 1 && return nothing
+    accsqr!(c[k], a[k >> 1])
+    return nothing
+end
+
+# in-place squaring: given `c`, compute expansion of `c^2` and save back into `c`
+function sqr!(c::Taylor1{T}, k::Int) where {T<:NumberNotSeries}
+    if k == 0
+        sqr_orderzero!(c, c)
+        return nothing
+    end
+    # Recursion formula
+    kodd = k%2
+    kend = (k - 2 + kodd) >> 1
+    (kend >= 0) && ( @inbounds c[k] = c[0] * c[k] )
+    @inbounds for i = 1:kend
+        c[k] += c[i] * c[k-i]
+    end
+    @inbounds c[k] = 2 * c[k]
+    (kodd == 0) && ( @inbounds c[k] += c[k >> 1]^2 )
+    return nothing
+end
+
+function sqr!(c::TaylorN{T}, k::Int) where {T<:NumberNotSeries}
+    if k == 0
+        sqr_orderzero!(c, c)
+        return nothing
+    end
+    # Recursion formula
+    kodd = k%2
+    kend = (k - 2 + kodd) >> 1
+    (kend >= 0) && ( @inbounds mul!(c, c[0][1], c, k) )
+    @inbounds for i = 1:kend
+        mul!(c[k], c[i], c[k-i])
+    end
+    @inbounds mul!(c, 2, c, k)
+    if kodd == 0
+        accsqr!(c[k], c[k >> 1])
+    end
+    return nothing
 end
 
 function sqr!(res::Taylor1{TaylorN{T}}, a::Taylor1{TaylorN{T}}, aux::TaylorN{T},


### PR DESCRIPTION
Currently, there are some patterns in the code which go along the lines of
```julia
for T in (:Taylor1, :TaylorN)
    # NOTE: For $T = TaylorN, `mul!` *accumulates* the result of a * b in c[k]
    @eval @inline function mul!(c::$T{T}, a::$T{T}, b::$T{T}, k::Int) where {T<:Number}
        if $T == Taylor1
            @inbounds c[k] = a[0] * b[k]
            @inbounds for i = 1:k
                c[k] += a[i] * b[k-i]
            end
        else
            @inbounds mul!(c[k], a[0], b[k])
            @inbounds for i = 1:k
                mul!(c[k], a[i], b[k-i])
            end
        end
        return nothing
    end
# ...
end
```
(these lines can be be found around here:https://github.com/JuliaDiff/TaylorSeries.jl/blob/05858833de9434cdc910eaa09eec557a114e1d2f/src/arithmetic.jl#L511 )

I gather such patterns avoid code repetitions, while generally the "cost" of running these `if`s, which are evaluated at runtime, is quite low. Just for the sake of confirming this, I experimented a bit with generated functions, which allow to preserve the specialization for each type while avoiding code repetition, with the advantage of resolving them at compilation time, instead of being checked during run time once per method call. This can become important when handling mixtures of `Taylor1{TaylorN{T}}` in TaylorIntegration, where the number of coefficients can be quite large, and these if's can be checked many times during run time, when it's only necessary to check them at dispatch.

Gotten to this point, though, maybe an equally good solution would be to simply separate `Taylor1` and `TaylorN` methods for patterns such as above? The latter can be more friendly to develop, and would avoid the use of generated functions, which looks maybe a bit overkill here?

So essentially what I'm proposing is to either remove the `if $T == Taylor1 ...` in the way they are now, or keep them by using generated functions, such that performance can improve a bit. Benchmarks I've run with TaylorIntegration on JT integrations show ~5% performance improvement. Not much indeed, but can be meaningful for longer runs.