### PR TITLE
Override Base.sum!

### DIFF
--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -40,7 +40,7 @@ import Base: iterate, size, eachindex, firstindex, lastindex,
     eltype, length, getindex, setindex!, axes, copyto!
 
 import Base: zero, one, zeros, ones, isinf, isnan, iszero, isless,
-    convert, promote_rule, promote, show,
+    convert, promote_rule, promote, show, sum!,
     real, imag, conj, adjoint,
     rem, mod, mod2pi, abs, abs2,
     sqrt, exp, expm1, log, log1p,

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -418,6 +418,15 @@ for T in (:Taylor1, :TaylorN)
     end
 end
 
+function sum!(v::TaylorN{S}, a::AbstractArray{HomogeneousPolynomial{S}}) where {S <: Number}
+    for i in eachindex(a)
+        for k in eachindex(v)
+            add!(v, v, a[i], k)
+        end
+    end
+    return nothing
+end
+
 ## Multiplication ##
 for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -405,6 +405,18 @@ for (f, fc) in ((:+, :(add!)), (:-, :(subst!)))
     end
 end
 
+for T in (:Taylor1, :TaylorN)
+    @eval begin
+        function sum!(v::$T{S}, a::AbstractArray{$T{S}}) where {S <: Number}
+            for i in eachindex(a)
+                for k in eachindex(v)
+                    add!(v, v, a[i], k)
+                end
+            end
+            return nothing
+        end
+    end
+end
 
 ## Multiplication ##
 for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)


### PR DESCRIPTION
This PR leverages `TS.add!` to reduce allocations when summing an array of Taylors. For instance:
```julia
# Generate a vector of random Taylor1s
order = 25
n = 10_000
v = [Taylor1(randn(order)) for _ in 1:n]
# New sum! method
y = zero(v[1])
sum!(y, v)
# Compare with existing methods
y == +(v...) # true
y ≈ sum(v) # true
# Benchmark
@time +(v...)
# 0.002061 seconds (30.00 k allocations: 3.357 MiB)
@time sum(v)
# 0.001163 seconds (10.00 k allocations: 2.441 MiB)
@time begin
    y = zero(v[1])
    sum!(y, v)
end
# 0.000688 seconds (3 allocations: 320 bytes)
```