### PR TITLE
compat: extend JLD2 to support v0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
-version = "0.20.8"
+version = "0.20.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -23,7 +23,7 @@ TaylorSeriesSAExt = "StaticArrays"
 [compat]
 Aqua = "0.8"
 IntervalArithmetic = "0.23, 1"
-JLD2 = "0.5"
+JLD2 = "0.5, 0.6"
 LinearAlgebra = "<0.0.1, 1"
 Markdown = "<0.0.1, 1"
 Random = "1"


### PR DESCRIPTION
This package is rather deep in my indirect dependency tree, but was causing some warnings for me through a combination of `CairoMakie` and some other packages. For whatever reason, the compat resolver prefers to use `JLD2 v0.6`, forcing this package to be downgraded to `v0.13.2`.

Likely misconfigured compat bound elsewhere, but extending JLD2 compat to cover v0.6 here seems to fix the issue in the sense that I can install the latest versions of this package and `JLD2`. Test for this package run successfully locally.

<details> <summary>see details</summary>

```julia-repl
julia> import ClimaCore

julia> import CairoMakie
WARNING: using IntervalArithmetic.numtype in module TaylorSeries conflicts with an existing identifier.
┌ Warning: Error requiring `IntervalArithmetic` from `TaylorSeries`
│   exception =
│    LoadError: UndefVarError: `IntervalBox` not defined in `TaylorSeries`
│    Suggestion: check for spelling errors or missing imports.
│    Stacktrace:
│      [1] top-level scope
│        @ ~/.julia/packages/TaylorSeries/ZBRjU/src/intervals.jl:171
│      [2] include(mod::Module, _path::String)
│        @ Base ./Base.jl:557
│      [3] include(x::String)
│        @ TaylorSeries ~/.julia/packages/TaylorSeries/ZBRjU/src/TaylorSeries.jl:17
│      [4] top-level scope
│        @ ~/.julia/packages/Requires/1eCOK/src/Requires.jl:40
│      [5] eval
│        @ ./boot.jl:430 [inlined]
│      [6] eval
│        @ ~/.julia/packages/TaylorSeries/ZBRjU/src/TaylorSeries.jl:17 [inlined]
│      [7] (::TaylorSeries.var"#54#57")()
│        @ TaylorSeries ~/.julia/packages/Requires/1eCOK/src/require.jl:101
│      [8] macro expansion
│        @ timing.jl:421 [inlined]
│      [9] err(f::Any, listener::Module, modname::String, file::String, line::Any)
│        @ Requires ~/.julia/packages/Requires/1eCOK/src/require.jl:47
│     [10] (::TaylorSeries.var"#53#56")()
│        @ TaylorSeries ~/.julia/packages/Requires/1eCOK/src/require.jl:100
│     [11] withpath(f::Any, path::String)
│        @ Requires ~/.julia/packages/Requires/1eCOK/src/require.jl:37
│     [12] (::TaylorSeries.var"#52#55")()
│        @ TaylorSeries ~/.julia/packages/Requires/1eCOK/src/require.jl:99
│     [13] #invokelatest#2
│        @ ./essentials.jl:1055 [inlined]
│     [14] invokelatest
│        @ ./essentials.jl:1052 [inlined]
│     [15] foreach(f::typeof(invokelatest), itr::Vector{Function})
│        @ Base ./abstractarray.jl:3187
│     [16] loadpkg(pkg::Base.PkgId)
│        @ Requires ~/.julia/packages/Requires/1eCOK/src/require.jl:27
│     [17] #invokelatest#2
│        @ ./essentials.jl:1055 [inlined]
│     [18] invokelatest
│        @ ./essentials.jl:1052 [inlined]
│     [19] run_package_callbacks(modkey::Base.PkgId)
│        @ Base ./loading.jl:1401
│     [20] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String, build_id::UInt128, stalecheck::Bool; reasons::Dict{String, Int64}, DEPOT_PATH::Vector{String})
│        @ Base ./loading.jl:2065
│     [21] _require(pkg::Base.PkgId, env::String)
│        @ Base ./loading.jl:2527
│     [22] __require_prelocked(uuidkey::Base.PkgId, env::String)
│        @ Base ./loading.jl:2388
│     [23] #invoke_in_world#3
│        @ ./essentials.jl:1089 [inlined]
│     [24] invoke_in_world
│        @ ./essentials.jl:1086 [inlined]
│     [25] _require_prelocked(uuidkey::Base.PkgId, env::String)
│        @ Base ./loading.jl:2375
│     [26] macro expansion
│        @ ./loading.jl:2314 [inlined]
│     [27] macro expansion
│        @ ./lock.jl:273 [inlined]
│     [28] __require(into::Module, mod::Symbol)
│        @ Base ./loading.jl:2271
│     [29] #invoke_in_world#3
│        @ ./essentials.jl:1089 [inlined]
│     [30] invoke_in_world
│        @ ./essentials.jl:1086 [inlined]
│     [31] require(into::Module, mod::Symbol)
│        @ Base ./loading.jl:2260
│     [32] top-level scope
│        @ none:1
│     [33] eval
│        @ ./boot.jl:430 [inlined]
│     [34] eval_user_input(ast::Any, backend::REPL.REPLBackend, mod::Module)
│        @ REPL /clima/software/julia/julia-1.11.5/share/julia/stdlib/v1.11/REPL/src/REPL.jl:261
│     [35] repl_backend_loop(backend::REPL.REPLBackend, get_module::Function)
│        @ REPL /clima/software/julia/julia-1.11.5/share/julia/stdlib/v1.11/REPL/src/REPL.jl:368
│     [36] start_repl_backend(backend::REPL.REPLBackend, consumer::Any; get_module::Function)
│        @ REPL /clima/software/julia/julia-1.11.5/share/julia/stdlib/v1.11/REPL/src/REPL.jl:343
│     [37] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool, backend::Any)
│        @ REPL /clima/software/julia/julia-1.11.5/share/julia/stdlib/v1.11/REPL/src/REPL.jl:500
│     [38] run_repl(repl::REPL.AbstractREPL, consumer::Any)
│        @ REPL /clima/software/julia/julia-1.11.5/share/julia/stdlib/v1.11/REPL/src/REPL.jl:486
│     [39] (::Base.var"#1150#1152"{Bool, Symbol, Bool})(REPL::Module)
│        @ Base ./client.jl:446
│     [40] #invokelatest#2
│        @ ./essentials.jl:1055 [inlined]
│     [41] invokelatest
│        @ ./essentials.jl:1052 [inlined]
│     [42] run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_file::Bool, color_set::Bool)
│        @ Base ./client.jl:430
│     [43] repl_main
│        @ ./client.jl:567 [inlined]
│     [44] _start()
│        @ Base ./client.jl:541
│    in expression starting at /home/haakon/.julia/packages/TaylorSeries/ZBRjU/src/intervals.jl:171
└ @ Requires ~/.julia/packages/Requires/1eCOK/src/require.jl:51
```

</details>

