### PR TITLE
New functions `jacobianmatrix` and `hessianmatrix`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
-version = "0.21.7"
+version = "0.21.8"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
 
 [deps]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -41,6 +41,7 @@ integrate
 gradient
 jacobian
 jacobian!
+jacobianmatrix
 hessian
 hessian!
 hessianmatrix

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -43,6 +43,7 @@ jacobian
 jacobian!
 hessian
 hessian!
+hessianmatrix
 constant_term
 linear_polynomial
 nonlinear_polynomial

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -512,17 +512,19 @@ functions *are not* exported, so its use require the
 prefix `TaylorSeries`. Using the
 polynomials ``p = x^3 + 2x^2 y - 7 x + 2`` and ``q = y-x^4`` defined above,
 we may use [`TaylorSeries.gradient`](@ref) (or `∇`); the results are of
-type `Array{TaylorN{T},1}`. To compute the Jacobian and Hessian of a vector field
-evaluated at a point, we use respectively [`TaylorSeries.jacobian`](@ref) and
-[`TaylorSeries.hessian`](@ref):
-
+type `Array{TaylorN{T},1}`:
 ```@repl userguide
 ∇(p)
 TaylorSeries.gradient( q )
+```
+To compute the Jacobian and Hessian of a vector field, we use respectively [`TaylorSeries.jacobianmatrix`](@ref) and [`TaylorSeries.hessianmatrix`](@ref), which return an `Array{TaylorN{T}, 2}`. In case we also want to evaluate the partial derivatives, [`TaylorSeries.jacobian`](@ref) and
+[`TaylorSeries.hessian`](@ref) are more efficient:
+```@repl userguide
 r = p-q-2*p*q
-TaylorSeries.hessian(ans)
-TaylorSeries.jacobian([p,q], [2,1])
+TaylorSeries.hessianmatrix(r)
 TaylorSeries.hessian(r, [1.0,1.0])
+TaylorSeries.jacobianmatrix([p,q])
+TaylorSeries.jacobian([p,q], [2,1])
 ```
 
 Other specific applications are described in the

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -337,6 +337,26 @@ function jacobian!(jac::Array{T,2}, vf::Array{TaylorN{T},1},
     nothing
 end
 
+"""
+```
+    jacobianmatrix(vf)
+```
+
+Compute the jacobian matrix of `vf`, a vector of `TaylorN` polynomials.
+"""
+function jacobianmatrix(vf::Array{TaylorN{T},1}) where {T <: Number}
+    numVars = get_numvars()
+    jac = Matrix{TaylorN{T}}(undef, numVars, length(vf))
+    ntup = zeros(Int, numVars)
+    for j in axes(jac, 2)
+        for i in axes(jac, 1)
+            ntup .= 0
+            ntup[i] += 1
+            jac[i, j] = differentiate(vf[j], tuple(ntup...))
+        end
+    end
+    return transpose(jac)
+end
 
 """
 ```

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -369,6 +369,27 @@ hessian!(hes::Array{T,2}, f::TaylorN{T}, vals::Array{T,1}) where {T<:Number} =
 hessian!(hes::Array{T,2}, f::TaylorN{T}) where {T<:Number} =
     jacobian!(hes, gradient(f))
 
+"""
+```
+    hessianmatrix(f)
+```
+
+Return the hessian matrix (jacobian of the gradient) of `f::TaylorN`.
+"""
+function hessianmatrix(f::TaylorN{T}) where {T <: Number}
+    numVars = get_numvars()
+    hess = Matrix{TaylorN{T}}(undef, numVars, numVars)
+    ntup = zeros(Int, numVars)
+    for j in axes(hess, 2)
+        for i in axes(hess, 1)
+            ntup .= 0
+            ntup[i] += 1
+            ntup[j] += 1
+            hess[i, j] = differentiate(f, tuple(ntup...))
+        end
+    end
+    return hess
+end
 
 ##Integration
 """

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -662,6 +662,8 @@ end
     @test jac == TS.jacobian( [g1(xT+2,yT+1), g2(xT+2,yT+1)] )
     TS.jacobian!(jac, [f1,f2], [2,1])
     @test jac == TS.jacobian([f1,f2], [2,1])
+    @test evaluate.(TS.jacobianmatrix([f1,f2]), Ref([xT+2, yT+1])) ==
+        TS.jacobianmatrix( [g1(xT+2,yT+1), g2(xT+2,yT+1)] )
     @test TS.hessian( f1*f2 ) ==
         [differentiate((2,0), f1*f2) differentiate((1,1), (f1*f2));
          differentiate((1,1), f1*f2) differentiate((0,2), (f1*f2))] == [4 -7; -7 0]

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -684,6 +684,13 @@ end
     TS.hessian!(hes1, f1-f2,[1,-1])
     TS.hessian!(hes, g1(xT+1,yT-1)-g2(xT+1,yT-1))
     @test hes1 == hes
+    @test TS.hessianmatrix( f1*f2 )() == TS.hessian( f1*f2 )
+    @test TS.hessianmatrix( f1*f2 ) == TS.hessian( f1*f2, [xT, yT] )
+    @test ([xT yT]*TS.hessianmatrix(f1*f2)*[xT, yT])[1][2] == 2*TaylorN((f1*f2)[2])
+    @test constant_term.(TS.hessianmatrix(f1^2)/2) == TS.hessian(f1^2)/2
+    @test TS.hessianmatrix(f1-f2-2*f1*f2) == (TS.hessianmatrix(f1-f2-2*f1*f2))'
+    @test evaluate.(TS.hessianmatrix(f1-f2), Ref([xT+1,yT-1])) ==
+          TS.hessianmatrix(g1(xT+1,yT-1)-g2(xT+1,yT-1))
 
     use_show_default(true)
     aa = sqrt(2) * xH


### PR DESCRIPTION
This PR defines two new functions `jacobianmatrix` and `hessianmatrix` which compute the matrix of first (second) partial derivatives of a `Vector{TaylorN}` (`TaylorN`) without evaluating.

@lbenet Any comments?