### PR TITLE
Define `JetSpace` equality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
-version = "0.22.1"
+version = "0.22.2"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
 
 [deps]

--- a/src/hash_tables.jl
+++ b/src/hash_tables.jl
@@ -243,12 +243,16 @@ such as `variables!` replace `default_space[]` with `space`. Existing `TaylorN`
 and `HomogeneousPolynomial` objects keep their original spaces, while future
 default-space constructors use the new default algebra.
 
+If `space` is structurally equal to the current default space, the existing
+default space object is kept and returned.
+
 Use `nowarn=true` to suppress the warning emitted when replacing the default
 space.
 """
 function set_default_space!(space::JetSpace; nowarn::Bool=false)
     old_space = default_space[]
     old_space === space && return space
+    old_space == space && return old_space
 
     msg = "Updating TaylorSeries.default_space[]; existing TaylorN and " *
         "HomogeneousPolynomial objects keep their original JetSpace, while " *

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -196,6 +196,38 @@ order(space::JetSpace) = space.order
 get_numvars(space::JetSpace) = space.num_vars
 get_variable_names(space::JetSpace) = space.variable_names
 get_variable_symbols(space::JetSpace) = space.variable_symbols
+
+function Base.:(==)(a::JetSpace, b::JetSpace)
+    a === b && return true
+    return order(a) == order(b) &&
+        get_numvars(a) == get_numvars(b) &&
+        get_variable_names(a) == get_variable_names(b) &&
+        get_variable_symbols(a) == get_variable_symbols(b)
+end
+
+function Base.hash(space::JetSpace, h::UInt)
+    return hash((JetSpace, order(space), get_numvars(space),
+        Tuple(get_variable_names(space)), Tuple(get_variable_symbols(space))), h)
+end
+
+function _space_spec_matches(space::JetSpace, order::Int,
+        variable_names::Vector{String})
+    TS.order(space) == order || return false
+    get_numvars(space) == length(variable_names) || return false
+    @inbounds for i in eachindex(variable_names)
+        space.variable_names[i] == variable_names[i] || return false
+        space.variable_symbols[i] == Symbol(variable_names[i]) || return false
+    end
+    return true
+end
+
+function _default_space_for(order::Int, variable_names::Vector{String};
+        nowarn::Bool=false)
+    space = default_space[]
+    _space_spec_matches(space, order, variable_names) && return space
+    return set_default_space!(JetSpace(order, variable_names), nowarn=nowarn)
+end
+
 function lookupvar(s::Symbol)
     ind = findfirst(x -> x==s, get_variable_symbols())
     isa(ind, Nothing) && return 0
@@ -237,8 +269,10 @@ independent variable. `names` defines the output for each variable
 (separated by a space). The default type `T` is `Float64`,
 and the default for `order` is the current default-space order.
 
-This function updates the compatibility default `JetSpace`. Set `nowarn=true`
-to suppress the warning emitted when the default space changes.
+This function updates the compatibility default `JetSpace`. If the requested
+space has the same order and variables as the current default, the existing
+default space is reused. Set `nowarn=true` to suppress the warning emitted when
+the default space changes.
 
 If `numvars` is not specified, it is inferred from `names`. If only
 one variable name is defined and `numvars>1`, it uses this name with
@@ -266,7 +300,7 @@ function variables!(::Type{R}, names::Vector{T}; order=TS.order(),
         nowarn::Bool=false) where
         {R, T<:AbstractString}
 
-    space = set_default_space!(JetSpace(order, _variable_names_from(names));
+    space = _default_space_for(order, _variable_names_from(names),
         nowarn=nowarn)
 
     # return a list of the new variables

--- a/src/total_order.jl
+++ b/src/total_order.jl
@@ -21,7 +21,7 @@ function ==(a::Taylor1{T}, b::Taylor1{T}) where {T<:Number}
 end
 
 function ==(a::TaylorN{T}, b::TaylorN{T}) where {T<:Number}
-    space(a) === space(b) || return false
+    space(a) == space(b) || return false
     if order(a) != order(b)
         a, b = fixorder(a, b)
     end
@@ -35,7 +35,7 @@ end
 ==(b::TaylorN{Taylor1{S}}, a::Taylor1{TaylorN{T}}) where {T, S} = a == b
 
 function ==(a::HomogeneousPolynomial, b::HomogeneousPolynomial)
-    space(a) === space(b) || return false
+    space(a) == space(b) || return false
     order(a) == order(b) && return a.coeffs == b.coeffs
     return iszero(a.coeffs) && iszero(b.coeffs)
 end

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -54,33 +54,61 @@ using Test
     @test sp.pos_table[4][15] == 2
 
     default_space_warning = r"Updating TaylorSeries.default_space\[\]"
-    @test_logs (:warn, default_space_warning) variables!("w", order=2,
+    vars_w = @test_logs (:warn, default_space_warning) variables!("w", order=2,
         numvars=2)
-    @test_logs (:warn, default_space_warning) variables!(:w, order=2,
+    sp_w = TS.default_space[]
+    vars_w_same = @test_logs min_level=Base.CoreLogging.Warn variables!(:w, order=2,
         numvars=2)
-    @test_logs (:warn, default_space_warning) variables!(["w", "z"],
+    @test TS.default_space[] === sp_w
+    @test all(var -> var.space === sp_w, vars_w)
+    @test all(var -> var.space === sp_w, vars_w_same)
+
+    vars_wz = @test_logs (:warn, default_space_warning) variables!(["w", "z"],
         order=2)
-    @test_logs (:warn, default_space_warning) variables!([:w, :z], order=2)
-    @test_logs (:warn, default_space_warning) variables!(Int, "w", order=2,
+    sp_wz = TS.default_space[]
+    vars_wz_same = @test_logs min_level=Base.CoreLogging.Warn variables!([:w, :z], order=2)
+    @test TS.default_space[] === sp_wz
+    @test all(var -> var.space === sp_wz, vars_wz)
+    @test all(var -> var.space === sp_wz, vars_wz_same)
+
+    vars_q = @test_logs (:warn, default_space_warning) variables!(Int, "q", order=2,
         numvars=2)
-    @test_logs (:warn, default_space_warning) variables!(Int, :w, order=2,
+    sp_q = TS.default_space[]
+    vars_q_same = @test_logs min_level=Base.CoreLogging.Warn variables!(Int, :q, order=2,
         numvars=2)
-    @test_logs (:warn, default_space_warning) variables!(BigInt, ["w", "z"],
+    @test TS.default_space[] === sp_q
+    @test all(var -> var.space === sp_q, vars_q)
+    @test all(var -> var.space === sp_q, vars_q_same)
+
+    vars_wz_big = @test_logs (:warn, default_space_warning) variables!(BigInt, ["w", "z"],
         order=2)
-    @test_logs (:warn, default_space_warning) variables!(BigInt, [:w, :z],
+    sp_wz_big = TS.default_space[]
+    vars_wz_big_same = @test_logs min_level=Base.CoreLogging.Warn variables!(BigInt, [:w, :z],
         order=2)
+    @test TS.default_space[] === sp_wz_big
+    @test all(var -> var.space === sp_wz_big, vars_wz_big)
+    @test all(var -> var.space === sp_wz_big, vars_wz_big_same)
 end
 
 @testset "Explicit JetSpaces" begin
     sx = JetSpace(order=5, variables=[:x, :y, :z])
     sa = JetSpace(order=3, variables=[:a, :b])
+    sx_equiv = JetSpace(order=5, variables=[:x, :y, :z])
 
     x, y, z = variables(sx)
     a, b = variables(sa)
+    x_equiv, y_equiv, z_equiv = variables(sx_equiv)
 
     @test x.space === y.space === z.space === sx
     @test a.space === b.space === sa
     @test x.space !== a.space
+    @test sx == sx_equiv
+    @test hash(sx) == hash(sx_equiv)
+    @test sx !== sx_equiv
+    @test sx != sa
+    @test x == x_equiv
+    @test x[1] == x_equiv[1]
+    @test_throws ArgumentError x + x_equiv
     @test order(x) == order(sx)
     x_low_order = variables(sx, order=2)[1]
     @test order(x_low_order) == 2


### PR DESCRIPTION
This PR is an attempt to fix #417:

- Adds structural `JetSpace` `==` and matching hash. By structural I mean comparing order, number of variables, variable names, and symbols, not caches/locks.
- Updates `TaylorN` and `HomogeneousPolynomial` equality to use `space(a) == space(b)`.
- Leaves arithmetic checks identity-based via `_check_same_space`, so mixed-space operations still throw.
- Updates `set_default_space!` to keep and return the existing default object when the incoming space is structurally equal.
- Updates `variables!` to reuse the existing default space instead of constructing/replacing an equivalent one.
- Adds tests for equality, hashing, no-warning reuse, and continued arithmetic rejection across distinct space identities.

cc: @lbenet @schillic

