### PR TITLE
Define `round(::AbstractSeries, ::RoundingMode)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TaylorSeries"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
-version = "0.22.4"
+version = "0.22.5"
 repo = "https://github.com/JuliaDiff/TaylorSeries.jl.git"
 
 [deps]

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -24,6 +24,7 @@ for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
 end
 
 # Rounding
+round(x::AbstractSeries, r::RoundingMode; kwargs...) = round(constant_term(x), r; kwargs...)
 round(::Type{T}, x::AbstractSeries; kwargs...) where {T <: NumberNotSeries} =
     round(T, x, RoundNearest; kwargs...)
 round(::Type{T}, x::AbstractSeries, r::RoundingMode; kwargs...) where {T <: NumberNotSeries} =

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -364,6 +364,7 @@ end
     @test (1/(1-xT))[3] == HomogeneousPolynomial([1.0],3)
     @test xH^20 == HomogeneousPolynomial([0], order())
     @test (yT/(1-xT))[4] == xH^3 * yH
+    @test round(1.0 + xT) === round(1.0 + yT) === round(1.0)
     @test round(Int, 1.0 + xT) === round(Int, 1.0 + yT) === round(Int, 1.0)
     @test mod(1+xT,1) == +xT
     @test (rem(1+xT,1))[0] == 0

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -126,6 +126,7 @@ using Test
         @test -2*tN1 < -tN1^2 ≤ 0
     end
 
+    @test round(tN1 + 1.0) === round(t1N + 1.0) === round(1.0)
     @test round(Int, tN1 + 1.0) === round(Int, t1N + 1.0) === round(Int, 1.0)
     @test mod(tN1+1,1.0) == 0+tN1
     @test mod(tN1-1.125,2) == 0.875+tN1

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -237,6 +237,7 @@ Base.iszero(::SymbNumber) = false
     @test trational^3/complex(7,1) == Taylor1([0,0,0,complex(7//50,-1//50)],15)
     @test sqrt(zero(t)) == zero(t)
 
+    @test round(4.1 + t) === round(4.1)
     @test round(Int, 4.1 + t) === round(Int, 4.1)
     @test isapprox( rem(4.1 + t,4)[0], 0.1 )
     @test isapprox( mod(4.1 + t,4)[0], 0.1 )


### PR DESCRIPTION
A new SatelliteToolboxTransformations minor version (v1.3) broke the tests in NEOs (see https://github.com/PerezHz/NEOs.jl/actions/runs/34602448371) by using yet another method for rounding `Number`s (`AbstractSeries` for NEOs). So, this PR defines the missing method (see https://github.com/JuliaDiff/TaylorSeries.jl/pull/421 for the original PR on rounding methods for `AbstractSeries`).